### PR TITLE
Fix #17: Improve error handling for README retrieval

### DIFF
--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -77,6 +77,18 @@ class GitHubService:
             "X-GitHub-Api-Version": "2022-11-28"
         }
 
+    def _check_repository_exists(self, username, repo):
+        """
+        Check if the repository exists using the GitHub API.
+        """
+        api_url = f"https://api.github.com/repos/{username}/{repo}"
+        response = requests.get(api_url, headers=self._get_headers())
+
+        if response.status_code == 404:
+            raise ValueError("Repository not found.")
+        elif response.status_code != 200:
+            raise Exception(f"Failed to check repository: {response.status_code}, {response.json()}")
+        
     def get_default_branch(self, username, repo):
         """Get the default branch of the repository."""
         api_url = f"https://api.github.com/repos/{username}/{repo}"
@@ -159,12 +171,20 @@ class GitHubService:
 
         Returns:
             str: The contents of the README file.
+
+        Raises:
+            ValueError: If repository does not exist or has no README.
+            Exception: For other unexpected API errors.
         """
+        # First check if the repository exists
+        self._check_repository_exists(username, repo)
+
+        # Then attempt to fetch the README
         api_url = f"https://api.github.com/repos/{username}/{repo}/readme"
         response = requests.get(api_url, headers=self._get_headers())
 
         if response.status_code == 404:
-            raise ValueError("Repository not found.")
+            raise ValueError("No README found for the specified repository.")
         elif response.status_code != 200:
             raise Exception(f"Failed to fetch README: {
                             response.status_code}, {response.json()}")


### PR DESCRIPTION
## Description
Fixes #17

This PR improves the error handling when fetching README files from GitHub repositories. It now correctly differentiates between:
- Non-existent/private repositories ("Repository not found")
- Public repositories without README files ("No README found for the specified repository")

## Changes
- Added `_check_repository_exists` method to verify repository existence
- Modified `get_github_readme` to implement two-step verification
- Updated error messages to be more precise and user-friendly

## Testing
Tested with the following scenarios:
- Public repository with README ✅
- Public repository without README ✅
- Private repository ✅
- Non-existent repository ✅

## Additional Notes
The implementation maintains all existing authentication functionality while providing more accurate error reporting.