### PR TITLE
fix: prevent default on ActionButton

### DIFF
--- a/src/components/action-button.tsx
+++ b/src/components/action-button.tsx
@@ -27,7 +27,10 @@ export function ActionButton({
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
-            onClick={onClick}
+            onClick={(e) => {
+              e.preventDefault();
+              onClick();
+            }}
             disabled={disabled}
             className="border-[3px] border-black bg-purple-400 p-4 px-4 text-base text-black shadow-[4px_4px_0_0_#000000] transition-transform hover:-translate-x-0.5 hover:-translate-y-0.5 hover:transform hover:bg-purple-400 sm:p-6 sm:px-6 sm:text-lg"
           >


### PR DESCRIPTION
Prevent form submission on ActionButton, allowing image export without the unintended behaviour of refreshing the page.