### PR TITLE
fix(button): update disabled state styles to include cursor behavior

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "~/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Changes
- Updated disabled button state to show `cursor-not-allowed` instead of blocking all pointer events
- Maintained visual opacity feedback (50%) for disabled state
- Preserved SVG pointer event blocking for consistent behavior

## Before
````tsx
disabled:pointer-events-none disabled:opacity-50
````

## After
````tsx
disabled:cursor-not-allowed disabled:opacity-50
````

## Why
This change improves the user experience by:
- ✨ Providing better visual feedback through cursor indication
- 🎯 Maintaining hover state visibility while preventing interactions
- 🔍 Making the disabled state more intuitive and user-friendly
- 🎨 Following established UI/UX patterns for disabled elements

## Testing
- [✅] Verified disabled button shows not-allowed cursor on hover
- [✅] Confirmed clicks are still prevented on disabled state
- [✅] Tested across all button variants

## Screenshots
![image](https://github.com/user-attachments/assets/45ac276f-20ef-4c4f-bfe4-5e0a79198e61)

## Related Issues
Closes #45 
