### PR TITLE
fix: diagram flex center

### DIFF
--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -86,7 +86,7 @@ const MermaidChart = ({ chart, zoomingEnabled = true }: MermaidChartProps) => {
     >
       <div
         key={`${chart}-${zoomingEnabled}`}
-        className={`mermaid h-full ${
+        className={`mermaid h-full flex justify-center ${
           zoomingEnabled ? "rounded-lg border-2 border-black" : ""
         }`}
       >


### PR DESCRIPTION
Maybe It's too weird to display the **diagram** on the left, so I added the 'justify-center'.
[bug case](https://gitdiagram.com/lharries/whatsapp-mcp)

(ps： i dont‘t know why i can't upload the screensnap 🥹, so i had to paste the case url.)

