### PR TITLE
Feature: add local service draft code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 POSTGRES_URL="postgresql://postgres:password@localhost:5432/gitdiagram"
 NEXT_PUBLIC_API_DEV_URL=http://localhost:8000
-ENABLE_LOCAL_SERVER=False
+ENABLE_LOCAL_SERVER=True
+LOCAL_CODEBASE="/app/code"
 OPENAI_API_KEY=
 
 # OPTIONAL: providing your own GitHub PAT increases rate limits from 60/hr to 5000/hr to the GitHub API

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 POSTGRES_URL="postgresql://postgres:password@localhost:5432/gitdiagram"
 NEXT_PUBLIC_API_DEV_URL=http://localhost:8000
-
+ENABLE_LOCAL_SERVER=False
 OPENAI_API_KEY=
 
 # OPTIONAL: providing your own GitHub PAT increases rate limits from 60/hr to 5000/hr to the GitHub API

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 POSTGRES_URL="postgresql://postgres:password@localhost:5432/gitdiagram"
 NEXT_PUBLIC_API_DEV_URL=http://localhost:8000
-ENABLE_LOCAL_SERVER=True
+ENABLE_LOCAL_SERVER=False
 LOCAL_CODEBASE="/app/code"
 OPENAI_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,55 @@ pnpm dev
 
 You can now access the website at `localhost:3000` and edit the rate limits defined in `backend/app/routers/generate.py` in the generate function decorator.
 
+## How to run it on local direcotry
+Make sure you already can go through the Self-hosting correctly.
+1. Create env file
+```bash
+cp .env.example .env
+```
+Change the `ENABLE_LOCAL_SERVER` to `True`
+
+2. Mount directrory
+Change the `docker-compose.yml`, mount your local directory at volumns. For example, if you want to generate the diagram of directory `/Users/xxx/my-project`. Add one line: `- /Users/xxx/my-project:/app/code` like below:
+```
+services:
+  api:
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+      - /Users/xxx/my-project:/app/code
+    env_file:
+      - .env
+    environment:
+      - ENVIRONMENT=${ENVIRONMENT:-development} # Default to development if not set
+    restart: unless-stopped
+```
+
+3. Run the following command to launch service.
+run it.
+```bash
+docker-compose up --build -d
+chmod +x start-database.sh
+./start-database.sh
+pnpm db:push
+pnpm dev
+```
+
+4. Go `localhost:3000` and just input any valide github url, eg `https://github.com/yufansong/gitdiagram`. It won't real generate the diagram of that github url, but will trigger the logic to generate the diagram of your local directory previously assigned. 
+
+5. If you meet the "syntax error" like this issue: `https://github.com/ahmedkhaleel2004/gitdiagram/issues/64`. It result from the lack of modal ability. The LLM generated mermaid js is not correct. My temprory solution is:
+- Go `backend` directory, you will find `mermaid.txt`. 
+- Throw it into an online mermaid editor like this `https://www.mermaidchart.com/play`, then you should get an error if you input the content of `mermaid.txt`.
+- Put the `mermaid.txt` and the error log into GPT, let it give you a correct mermard code.
+- Go back to `https://www.mermaidchart.com/play` and retry, you will get the result.
+
+As least for me, I can get correctly result for several times by above solution.
+
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/backend/app/routers/generate.py
+++ b/backend/app/routers/generate.py
@@ -25,7 +25,7 @@ ENABLE_LOCAL_SERVER = os.getenv("ENABLE_LOCAL_SERVER") == "true" \
      or os.getenv("ENABLE_LOCAL_SERVER") == "TRUE" \
      or os.getenv("ENABLE_LOCAL_SERVER") == "1" \
      or os.getenv("ENABLE_LOCAL_SERVER") == 1
-
+LOCAL_CODEBASE = os.getenv("LOCAL_CODEBASE")
 router = APIRouter(prefix="/generate", tags=["Claude"])
 
 # Initialize services
@@ -45,7 +45,7 @@ def dump_mermaid_code(mermaid_code):
 @lru_cache(maxsize=100)
 def get_cached_github_data(username: str, repo: str, github_pat: str | None = None):
     if ENABLE_LOCAL_SERVER:
-        return get_cached_local_data(local_path=repo)
+        return get_cached_local_data(local_path=LOCAL_CODEBASE)
     # Create a new service instance for each call with the appropriate PAT
     service = GitHubService(pat=github_pat)
 
@@ -61,11 +61,9 @@ def get_cached_github_data(username: str, repo: str, github_pat: str | None = No
 @lru_cache(maxsize=100)
 def get_cached_local_data(local_path: str):
     # Create a new service instance for each call with the appropriate PAT
-    service = LocalService(pat=local_path)
-
+    service = LocalService(path=local_path)
     file_tree = service.get_file_paths_as_list()
     readme = service.get_readme()
-
     return {"default_branch": "Your Current Branch", "file_tree": file_tree, "readme": readme}
 
 

--- a/backend/app/routers/generate.py
+++ b/backend/app/routers/generate.py
@@ -32,6 +32,15 @@ router = APIRouter(prefix="/generate", tags=["Claude"])
 # claude_service = ClaudeService()
 o3_service = OpenAIo3Service()
 
+
+def dump_mermaid_code(mermaid_code):
+    output_dir = "/app"
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, "mermaid.txt"), "w") as f:
+        f.write(mermaid_code)  # directly write to mermaid.txt
+    return
+
+
 # cache github data to avoid double API calls from cost and generate
 @lru_cache(maxsize=100)
 def get_cached_github_data(username: str, repo: str, github_pat: str | None = None):
@@ -261,6 +270,10 @@ async def generate_stream(request: Request, body: ApiRequest):
                 processed_diagram = process_click_events(
                     mermaid_code, body.username, body.repo, default_branch
                 )
+
+                # dump the generated mermaid code
+                # will be useful when debugging
+                dump_mermaid_code(mermaid_code)
 
                 # Send final result
                 yield f"data: {json.dumps({

--- a/backend/app/routers/generate.py
+++ b/backend/app/routers/generate.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import StreamingResponse
 from dotenv import load_dotenv
 from app.services.github_service import GitHubService
+from app.services.local_service import LocalService
 from app.services.o3_mini_openai_service import OpenAIo3Service
 from app.prompts import (
     SYSTEM_FIRST_PROMPT,
@@ -15,11 +16,15 @@ from functools import lru_cache
 import re
 import json
 import asyncio
-
 # from app.services.claude_service import ClaudeService
 # from app.core.limiter import limiter
-
+import os
 load_dotenv()
+ENABLE_LOCAL_SERVER = os.getenv("ENABLE_LOCAL_SERVER") == "true" \
+     or os.getenv("ENABLE_LOCAL_SERVER") == "True" \
+     or os.getenv("ENABLE_LOCAL_SERVER") == "TRUE" \
+     or os.getenv("ENABLE_LOCAL_SERVER") == "1" \
+     or os.getenv("ENABLE_LOCAL_SERVER") == 1
 
 router = APIRouter(prefix="/generate", tags=["Claude"])
 
@@ -27,21 +32,32 @@ router = APIRouter(prefix="/generate", tags=["Claude"])
 # claude_service = ClaudeService()
 o3_service = OpenAIo3Service()
 
-
 # cache github data to avoid double API calls from cost and generate
 @lru_cache(maxsize=100)
 def get_cached_github_data(username: str, repo: str, github_pat: str | None = None):
+    if ENABLE_LOCAL_SERVER:
+        return get_cached_local_data(local_path=repo)
     # Create a new service instance for each call with the appropriate PAT
-    current_github_service = GitHubService(pat=github_pat)
+    service = GitHubService(pat=github_pat)
 
-    default_branch = current_github_service.get_default_branch(username, repo)
+    default_branch = service.get_default_branch(username, repo)
     if not default_branch:
         default_branch = "main"  # fallback value
 
-    file_tree = current_github_service.get_github_file_paths_as_list(username, repo)
-    readme = current_github_service.get_github_readme(username, repo)
+    file_tree = service.get_file_paths_as_list(username, repo)
+    readme = service.get_readme(username, repo)
 
     return {"default_branch": default_branch, "file_tree": file_tree, "readme": readme}
+
+@lru_cache(maxsize=100)
+def get_cached_local_data(local_path: str):
+    # Create a new service instance for each call with the appropriate PAT
+    service = LocalService(pat=local_path)
+
+    file_tree = service.get_file_paths_as_list()
+    readme = service.get_readme()
+
+    return {"default_branch": "Your Current Branch", "file_tree": file_tree, "readme": readme}
 
 
 class ApiRequest(BaseModel):

--- a/backend/app/services/base_service.py
+++ b/backend/app/services/base_service.py
@@ -11,12 +11,42 @@ class BaseService(ABC):
 
     # Shared utility method can be implemented here
     def _should_include_file(self, path):
+        # Patterns to exclude
         excluded_patterns = [
-            "node_modules/", "vendor/", "venv/",
-            ".min.", ".pyc", ".pyo", ".pyd",
-            ".jpg", ".jpeg", ".png", ".gif",
-            "__pycache__/", ".cache/", ".tmp/",
-            "yarn.lock", "poetry.lock", "*.log",
-            ".vscode/", ".idea/"
+            # Dependencies
+            "node_modules/",
+            "vendor/",
+            "venv/",
+            # Compiled files
+            ".min.",
+            ".pyc",
+            ".pyo",
+            ".pyd",
+            ".so",
+            ".dll",
+            ".class",
+            # Asset files
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+            ".ico",
+            ".svg",
+            ".ttf",
+            ".woff",
+            ".webp",
+            # Cache and temporary files
+            "__pycache__/",
+            ".cache/",
+            ".tmp/",
+            # Lock files and logs
+            "yarn.lock",
+            "poetry.lock",
+            "*.log",
+            # Configuration files
+            ".vscode/",
+            ".idea/",
         ]
+
         return not any(pattern in path.lower() for pattern in excluded_patterns)
+  

--- a/backend/app/services/base_service.py
+++ b/backend/app/services/base_service.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+
+class BaseService(ABC):
+    @abstractmethod
+    def get_file_paths_as_list(self, username, repo):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_readme(self, username, repo):
+        raise NotImplementedError
+
+    # Shared utility method can be implemented here
+    def _should_include_file(self, path):
+        excluded_patterns = [
+            "node_modules/", "vendor/", "venv/",
+            ".min.", ".pyc", ".pyo", ".pyd",
+            ".jpg", ".jpeg", ".png", ".gif",
+            "__pycache__/", ".cache/", ".tmp/",
+            "yarn.lock", "poetry.lock", "*.log",
+            ".vscode/", ".idea/"
+        ]
+        return not any(pattern in path.lower() for pattern in excluded_patterns)

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -4,11 +4,11 @@ import time
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import os
+from .base_service import BaseService
 
 load_dotenv()
 
-
-class GitHubService:
+class GitHubService(BaseService):
     def __init__(self, pat: str | None = None):
         # Try app authentication first
         self.client_id = os.getenv("GITHUB_CLIENT_ID")
@@ -107,7 +107,7 @@ class GitHubService:
             return response.json().get("default_branch")
         return None
 
-    def get_github_file_paths_as_list(self, username, repo):
+    def get_file_paths_as_list(self, username, repo):
         """
         Fetches the file tree of an open-source GitHub repository,
         excluding static files and generated code.
@@ -119,47 +119,6 @@ class GitHubService:
         Returns:
             str: A filtered and formatted string of file paths in the repository, one per line.
         """
-
-        def should_include_file(path):
-            # Patterns to exclude
-            excluded_patterns = [
-                # Dependencies
-                "node_modules/",
-                "vendor/",
-                "venv/",
-                # Compiled files
-                ".min.",
-                ".pyc",
-                ".pyo",
-                ".pyd",
-                ".so",
-                ".dll",
-                ".class",
-                # Asset files
-                ".jpg",
-                ".jpeg",
-                ".png",
-                ".gif",
-                ".ico",
-                ".svg",
-                ".ttf",
-                ".woff",
-                ".webp",
-                # Cache and temporary files
-                "__pycache__/",
-                ".cache/",
-                ".tmp/",
-                # Lock files and logs
-                "yarn.lock",
-                "poetry.lock",
-                "*.log",
-                # Configuration files
-                ".vscode/",
-                ".idea/",
-            ]
-
-            return not any(pattern in path.lower() for pattern in excluded_patterns)
-
         # Try to get the default branch first
         branch = self.get_default_branch(username, repo)
         if branch:
@@ -174,7 +133,7 @@ class GitHubService:
                     paths = [
                         item["path"]
                         for item in data["tree"]
-                        if should_include_file(item["path"])
+                        if self._should_include_file(item["path"])
                     ]
                     return "\n".join(paths)
 
@@ -191,7 +150,7 @@ class GitHubService:
                     paths = [
                         item["path"]
                         for item in data["tree"]
-                        if should_include_file(item["path"])
+                        if self._should_include_file(item["path"])
                     ]
                     return "\n".join(paths)
 
@@ -199,7 +158,7 @@ class GitHubService:
             "Could not fetch repository file tree. Repository might not exist, be empty or private."
         )
 
-    def get_github_readme(self, username, repo):
+    def get_readme(self, username, repo):
         """
         Fetches the README contents of an open-source GitHub repository.
 

--- a/backend/app/services/local_service.py
+++ b/backend/app/services/local_service.py
@@ -1,0 +1,147 @@
+import requests
+import jwt
+import time
+from datetime import datetime, timedelta
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+
+class LocalService:
+    def __init__(self, path: str | None = None):
+        self.path = path
+
+    def _get_headers(self):
+        return {
+            "Authorization": "Bearer",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def get_default_branch(self, username, repo):
+        """Get the default branch of the repository."""
+        api_url = f"https://api.github.com/repos/{username}/{repo}"
+        response = requests.get(api_url, headers=self._get_headers())
+
+        if response.status_code == 200:
+            return response.json().get("default_branch")
+        return None
+
+    # 新增本地文件处理方法
+    def get_github_file_paths_as_list(self, local_path: str, username=None):
+        """
+        Get the file paths of the local codebase, excluding static files and generated code.
+        
+        Args:
+            local_path (str): the absolute path of the local codebase
+            
+        Returns:
+            str: file path list after filtering
+        """
+        from pathlib import Path
+        
+        def scan_directory(path: Path):
+            """recursively scan the directory"""
+            paths = []
+            for entry in path.iterdir():
+                if entry.name.startswith('.'):  # 排除隐藏文件/目录
+                    continue
+                if entry.is_dir():
+                    paths.extend(scan_directory(entry))
+                else:
+                    file_path = str(entry.relative_to(base_path))  # 修改这里使用 base_path
+                    if self._should_include_file(file_path):
+                        paths.append(file_path)
+            return paths
+        
+        try:
+            base_path = Path(local_path) 
+            if not base_path.exists():
+                raise ValueError(f"Local path not exist {local_path}")
+            if not base_path.is_dir():
+                raise ValueError("Should provide a valid directory path")
+                
+            all_files = scan_directory(base_path)
+            return "\n".join(all_files)
+            
+        except Exception as e:
+            raise ValueError(f"Connot read local file: {str(e)}")
+
+    def get_github_readme(self, username, repo):
+        """
+        获取本地代码库的README内容
+        
+        Args:
+            local_path (str): the absolute path of the local codebase
+            
+        Returns:
+            str: README file content
+            
+        Raises:
+            ValueError: throw when readme file is not found
+            FileNotFoundError: throw when readme file is not found
+        """
+        from pathlib import Path
+        local_path = "/app/code/evals"
+        
+        base_path = Path(local_path)
+        if not base_path.exists():
+            raise ValueError("The local path does not exist.")
+        if not base_path.is_dir():
+            raise ValueError("The provided path is not a directory.")
+            
+        readme_files = ['README.md', 'README', 'readme.md']
+        for filename in readme_files:
+            readme_path = base_path / filename
+            if readme_path.is_file():
+                try:
+                    return readme_path.read_text(encoding='utf-8')
+                except UnicodeDecodeError:
+                    continue
+                
+        raise FileNotFoundError("Cannot find the available readme file (support README.md/README/readme.md)")
+   
+    def _should_include_file(self, path):
+        """
+        keep the original logic for filtering files
+        """
+        # Patterns to exclude
+        excluded_patterns = [
+            # Dependencies
+            "node_modules/",
+            "vendor/",
+            "venv/",
+            # Compiled files
+            ".min.",
+            ".pyc",
+            ".pyo",
+            ".pyd",
+            ".so",
+            ".dll",
+            ".class",
+            # Asset files
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+            ".ico",
+            ".svg",
+            ".ttf",
+            ".woff",
+            ".webp",
+            # Cache and temporary files
+            "__pycache__/",
+            ".cache/",
+            ".tmp/",
+            # Lock files and logs
+            "yarn.lock",
+            "poetry.lock",
+            "*.log",
+            # Configuration files
+            ".vscode/",
+            ".idea/",
+        ]
+
+        return not any(pattern in path.lower() for pattern in excluded_patterns)
+  

--- a/backend/app/services/local_service.py
+++ b/backend/app/services/local_service.py
@@ -4,96 +4,60 @@ import time
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import os
+from pathlib import Path
+from .base_service import BaseService
 
 load_dotenv()
 
-
-class LocalService:
+class LocalService(BaseService):  # Changed to inherit from BaseService
     def __init__(self, path: str | None = None):
         self.path = path
-
-    def _get_headers(self):
-        return {
-            "Authorization": "Bearer",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-
-    def get_default_branch(self, username, repo):
-        """Get the default branch of the repository."""
-        api_url = f"https://api.github.com/repos/{username}/{repo}"
-        response = requests.get(api_url, headers=self._get_headers())
-
-        if response.status_code == 200:
-            return response.json().get("default_branch")
-        return None
+        base_path = Path(self.path) 
+        if not base_path.exists():
+            raise ValueError(f"Local path not exist {self.path}")
+        if not base_path.is_dir():
+            raise ValueError("Should provide a valid directory path")
 
     # 新增本地文件处理方法
-    def get_github_file_paths_as_list(self, local_path: str, username=None):
+    def get_file_paths_as_list(self):
         """
         Get the file paths of the local codebase, excluding static files and generated code.
-        
-        Args:
-            local_path (str): the absolute path of the local codebase
-            
         Returns:
             str: file path list after filtering
         """
-        from pathlib import Path
-        
         def scan_directory(path: Path):
-            """recursively scan the directory"""
             paths = []
             for entry in path.iterdir():
-                if entry.name.startswith('.'):  # 排除隐藏文件/目录
+                if entry.name.startswith('.'):  # remove hidden files and folders
                     continue
                 if entry.is_dir():
                     paths.extend(scan_directory(entry))
                 else:
-                    file_path = str(entry.relative_to(base_path))  # 修改这里使用 base_path
+                    file_path = str(entry.relative_to(Path)) 
                     if self._should_include_file(file_path):
                         paths.append(file_path)
             return paths
         
         try:
-            base_path = Path(local_path) 
-            if not base_path.exists():
-                raise ValueError(f"Local path not exist {local_path}")
-            if not base_path.is_dir():
-                raise ValueError("Should provide a valid directory path")
-                
-            all_files = scan_directory(base_path)
+            all_files = scan_directory(Path(self.path) )
             return "\n".join(all_files)
             
         except Exception as e:
             raise ValueError(f"Connot read local file: {str(e)}")
 
-    def get_github_readme(self, username, repo):
+    def get_readme(self):
         """
-        获取本地代码库的README内容
-        
-        Args:
-            local_path (str): the absolute path of the local codebase
-            
+        Get the README file content of the local codebase.
         Returns:
             str: README file content
             
         Raises:
             ValueError: throw when readme file is not found
             FileNotFoundError: throw when readme file is not found
-        """
-        from pathlib import Path
-        local_path = "/app/code/evals"
-        
-        base_path = Path(local_path)
-        if not base_path.exists():
-            raise ValueError("The local path does not exist.")
-        if not base_path.is_dir():
-            raise ValueError("The provided path is not a directory.")
-            
+        """ 
         readme_files = ['README.md', 'README', 'readme.md']
         for filename in readme_files:
-            readme_path = base_path / filename
+            readme_path = Path(self.path) / filename
             if readme_path.is_file():
                 try:
                     return readme_path.read_text(encoding='utf-8')
@@ -101,47 +65,3 @@ class LocalService:
                     continue
                 
         raise FileNotFoundError("Cannot find the available readme file (support README.md/README/readme.md)")
-   
-    def _should_include_file(self, path):
-        """
-        keep the original logic for filtering files
-        """
-        # Patterns to exclude
-        excluded_patterns = [
-            # Dependencies
-            "node_modules/",
-            "vendor/",
-            "venv/",
-            # Compiled files
-            ".min.",
-            ".pyc",
-            ".pyo",
-            ".pyd",
-            ".so",
-            ".dll",
-            ".class",
-            # Asset files
-            ".jpg",
-            ".jpeg",
-            ".png",
-            ".gif",
-            ".ico",
-            ".svg",
-            ".ttf",
-            ".woff",
-            ".webp",
-            # Cache and temporary files
-            "__pycache__/",
-            ".cache/",
-            ".tmp/",
-            # Lock files and logs
-            "yarn.lock",
-            "poetry.lock",
-            "*.log",
-            # Configuration files
-            ".vscode/",
-            ".idea/",
-        ]
-
-        return not any(pattern in path.lower() for pattern in excluded_patterns)
-  

--- a/backend/app/services/local_service.py
+++ b/backend/app/services/local_service.py
@@ -18,32 +18,38 @@ class LocalService(BaseService):  # Changed to inherit from BaseService
         if not base_path.is_dir():
             raise ValueError("Should provide a valid directory path")
 
-    # 新增本地文件处理方法
     def get_file_paths_as_list(self):
         """
         Get the file paths of the local codebase, excluding static files and generated code.
         Returns:
             str: file path list after filtering
         """
-        def scan_directory(path: Path):
+        def scan_directory(base_path: Path):
+            """recursively scan directories and filter files"""
             paths = []
-            for entry in path.iterdir():
-                if entry.name.startswith('.'):  # remove hidden files and folders
+            for entry in base_path.iterdir():
+                if entry.name.startswith('.'): 
                     continue
                 if entry.is_dir():
                     paths.extend(scan_directory(entry))
                 else:
-                    file_path = str(entry.relative_to(Path)) 
+                    file_path = str(entry.relative_to(base_path))
                     if self._should_include_file(file_path):
                         paths.append(file_path)
             return paths
         
         try:
-            all_files = scan_directory(Path(self.path) )
+            base_path = Path(self.path) 
+            if not base_path.exists():
+                raise ValueError(f"local path not exist {self.path}")
+            if not base_path.is_dir():
+                raise ValueError("should provide the directory path")
+                
+            all_files = scan_directory(base_path)
             return "\n".join(all_files)
             
         except Exception as e:
-            raise ValueError(f"Connot read local file: {str(e)}")
+            raise ValueError(f"cannot read the local codebase: {str(e)}")
 
     def get_readme(self):
         """


### PR DESCRIPTION
Firstly, thanks for your project which is very interesting and helpful. 

This is more like a temporary solution for local directory generation. 
After the investigation, I find the code get the file name of all sub directory + readme content, then put those into GPT with some prompt engineering. But to be honest, I know nothing about frontend, I cannot change the frontend code. So this solution is a hacky one which can bypass the check of frontend github. 

I think many people want to use this project to generate local codebase diagram. I hope you can just open a seperate branch for me. Then I can put this update over there. But now, only main branch exists, so I just open one PR to main branch and put it here to hear your feedback.

If someone can help, I think just add a button in frontend, let people upload their file tree path and readme file, the local directory function could be easily supported.