### PR TITLE
Migrate diagram storage off Neon to R2 and Upstash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,18 @@
+# Optional only for one-time backfills or legacy local inspection.
 POSTGRES_URL="postgresql://postgres:password@localhost:5432/gitdiagram"
+DIAGRAM_CACHE_BACKEND=object
+QUOTA_BACKEND=upstash
+POSTGRES_FALLBACK_ENABLED=false
+
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_PUBLIC_BUCKET=
+R2_PRIVATE_BUCKET=
+CACHE_KEY_SECRET=
+
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
 # Choose exactly one generation backend mode: "fastapi" or "next".
 NEXT_PUBLIC_GENERATION_BACKEND=fastapi
 # Required when NEXT_PUBLIC_GENERATION_BACKEND=fastapi. Include the /generate suffix.

--- a/backend/app/routers/generate.py
+++ b/backend/app/routers/generate.py
@@ -78,6 +78,7 @@ def _get_github_data(username: str, repo: str, github_pat: str | None):
         default_branch=github_data.default_branch,
         file_tree=github_data.file_tree,
         readme=github_data.readme,
+        is_private=github_data.is_private,
     )
 
 
@@ -239,6 +240,7 @@ async def generate_stream(request: Request):
         quota_reservation = None
         actual_usages = []
         has_complete_measured_usage = True
+        storage_visibility = "private" if parsed.github_pat else "public"
 
         async def persist_audit() -> None:
             if not diagram_state_repository.is_configured():
@@ -249,6 +251,8 @@ async def generate_stream(request: Request):
                     username=parsed.username,
                     repo=parsed.repo,
                     audit=audit,
+                    visibility=storage_visibility,
+                    github_pat=parsed.github_pat,
                 )
             except Exception as exc:
                 log_event(
@@ -278,6 +282,8 @@ async def generate_stream(request: Request):
                     diagram=diagram,
                     audit=audit,
                     used_own_key=used_own_key,
+                    visibility=storage_visibility,
+                    github_pat=parsed.github_pat,
                 )
             except Exception as exc:
                 log_event(
@@ -293,6 +299,7 @@ async def generate_stream(request: Request):
 
         try:
             github_data = _get_github_data(parsed.username, parsed.repo, parsed.github_pat)
+            storage_visibility = "private" if getattr(github_data, "is_private", False) else "public"
             provider_label = get_provider_label(provider)
             estimate = await estimate_generation_cost(
                 provider=provider,
@@ -330,10 +337,10 @@ async def generate_stream(request: Request):
                 model=model,
                 api_key=parsed.api_key,
             ):
-                if not diagram_state_repository.is_configured():
+                if not diagram_state_repository.quota_is_configured():
                     error_message = (
-                        "OPENAI_COMPLIMENTARY_GATE_ENABLED requires POSTGRES_URL on the backend "
-                        "service because quota tracking is stored in Postgres."
+                        "OPENAI_COMPLIMENTARY_GATE_ENABLED requires a quota backend "
+                        "(POSTGRES_URL or Upstash Redis REST configuration)."
                     )
                     audit = _set_failure(
                         {

--- a/backend/app/services/diagram_state_repository.py
+++ b/backend/app/services/diagram_state_repository.py
@@ -1,17 +1,120 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
-from typing import Any
+from typing import Any, Literal
+from urllib.parse import quote
 
+import boto3
 import psycopg
+import requests
+from botocore.exceptions import ClientError
+
+ArtifactVisibility = Literal["public", "private"]
+
+STATUS_TTL_SECONDS = 3 * 24 * 60 * 60
+QUOTA_TTL_SECONDS = 3 * 24 * 60 * 60
+
+RESERVE_QUOTA_SCRIPT = """
+local key = KEYS[1]
+local token_limit = tonumber(ARGV[1])
+local reservation_tokens = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+
+local used_tokens = tonumber(redis.call("HGET", key, "used_tokens") or "0")
+local reserved_tokens = tonumber(redis.call("HGET", key, "reserved_tokens") or "0")
+
+if used_tokens + reserved_tokens + reservation_tokens > token_limit then
+  return {0, used_tokens, reserved_tokens}
+end
+
+local next_reserved_tokens = reserved_tokens + reservation_tokens
+redis.call("HSET", key, "used_tokens", used_tokens, "reserved_tokens", next_reserved_tokens)
+redis.call("EXPIRE", key, ttl)
+
+return {1, used_tokens, next_reserved_tokens}
+"""
+
+FINALIZE_QUOTA_SCRIPT = """
+local key = KEYS[1]
+local reservation_tokens = tonumber(ARGV[1])
+local committed_tokens = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+
+local used_tokens = tonumber(redis.call("HGET", key, "used_tokens") or "0")
+local reserved_tokens = tonumber(redis.call("HGET", key, "reserved_tokens") or "0")
+
+local next_reserved_tokens = reserved_tokens - reservation_tokens
+if next_reserved_tokens < 0 then
+  next_reserved_tokens = 0
+end
+
+local next_used_tokens = used_tokens + math.max(committed_tokens, 0)
+redis.call("HSET", key, "used_tokens", next_used_tokens, "reserved_tokens", next_reserved_tokens)
+redis.call("EXPIRE", key, ttl)
+
+return {next_used_tokens, next_reserved_tokens}
+"""
+
+
+def _read_env(name: str) -> str | None:
+    value = (os.getenv(name) or "").strip()
+    return value or None
+
+
+def _read_flag(name: str, default: bool = False) -> bool:
+    value = _read_env(name)
+    if value is None:
+      return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _normalize_segment(value: str) -> str:
+    return quote(value.strip().lower(), safe="")
 
 
 class DiagramStateRepository:
     def __init__(self) -> None:
-        self.database_url = (os.getenv("POSTGRES_URL") or "").strip()
+        self.database_url = _read_env("POSTGRES_URL") or ""
+        self.r2_account_id = _read_env("R2_ACCOUNT_ID")
+        self.r2_access_key_id = _read_env("R2_ACCESS_KEY_ID")
+        self.r2_secret_access_key = _read_env("R2_SECRET_ACCESS_KEY")
+        self.r2_public_bucket = _read_env("R2_PUBLIC_BUCKET")
+        self.r2_private_bucket = _read_env("R2_PRIVATE_BUCKET")
+        self.cache_key_secret = _read_env("CACHE_KEY_SECRET")
+        self.upstash_url = _read_env("UPSTASH_REDIS_REST_URL")
+        self.upstash_token = _read_env("UPSTASH_REDIS_REST_TOKEN")
+        self.cache_backend = (_read_env("DIAGRAM_CACHE_BACKEND") or ("object" if self._has_r2_config() else "postgres")).lower()
+        self.quota_backend = (_read_env("QUOTA_BACKEND") or ("upstash" if self._has_upstash_config() else "postgres")).lower()
+        self.postgres_fallback_enabled = _read_flag("POSTGRES_FALLBACK_ENABLED", False)
+        self._s3_client = None
+
+    def _has_r2_config(self) -> bool:
+        return bool(
+            self.r2_account_id
+            and self.r2_access_key_id
+            and self.r2_secret_access_key
+            and self.r2_public_bucket
+            and self.r2_private_bucket
+        )
+
+    def _has_upstash_config(self) -> bool:
+        return bool(self.upstash_url and self.upstash_token)
+
+    def _should_use_object_storage(self) -> bool:
+        return self.cache_backend in {"dual", "object"}
+
+    def _should_dual_write_postgres(self) -> bool:
+        return self.cache_backend == "dual" and bool(self.database_url)
 
     def is_configured(self) -> bool:
+        return bool(self.database_url) or self._has_r2_config() or self._has_upstash_config()
+
+    def quota_is_configured(self) -> bool:
+        if self.quota_backend == "upstash":
+            return self._has_upstash_config()
         return bool(self.database_url)
 
     def _connect(self):
@@ -19,7 +122,220 @@ class DiagramStateRepository:
             raise ValueError("Missing POSTGRES_URL for diagram state persistence.")
         return psycopg.connect(self.database_url)
 
-    def upsert_latest_session_audit(self, *, username: str, repo: str, audit: dict[str, Any]) -> None:
+    def _get_s3_client(self):
+        if self._s3_client is not None:
+            return self._s3_client
+        if not self._has_r2_config():
+            raise ValueError("Missing R2 configuration.")
+        self._s3_client = boto3.client(
+            "s3",
+            endpoint_url=f"https://{self.r2_account_id}.r2.cloudflarestorage.com",
+            aws_access_key_id=self.r2_access_key_id,
+            aws_secret_access_key=self.r2_secret_access_key,
+            region_name="auto",
+        )
+        return self._s3_client
+
+    def _upstash_headers(self) -> dict[str, str]:
+        if not self._has_upstash_config():
+            raise ValueError("Missing Upstash configuration.")
+        return {
+            "Authorization": f"Bearer {self.upstash_token}",
+            "Content-Type": "application/json",
+        }
+
+    def _upstash_command(self, command: list[Any]) -> Any:
+        if not self.upstash_url:
+            raise ValueError("Missing Upstash configuration.")
+        response = requests.post(
+            self.upstash_url.rstrip("/"),
+            headers=self._upstash_headers(),
+            json=command,
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("error"):
+            raise ValueError(f"Upstash command failed: {payload['error']}")
+        return payload.get("result")
+
+    def _upstash_eval(self, *, script: str, keys: list[str], args: list[Any]) -> Any:
+        if not self.upstash_url:
+            raise ValueError("Missing Upstash configuration.")
+        response = requests.post(
+            f"{self.upstash_url.rstrip('/')}/eval",
+            headers=self._upstash_headers(),
+            json={"script": script, "keys": keys, "args": args},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("error"):
+            raise ValueError(f"Upstash eval failed: {payload['error']}")
+        return payload.get("result")
+
+    def _pat_namespace(self, github_pat: str) -> str:
+        if not self.cache_key_secret:
+            raise ValueError("Missing CACHE_KEY_SECRET.")
+        return hmac.new(
+            self.cache_key_secret.encode("utf-8"),
+            github_pat.strip().encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def _resolve_visibility(
+        self,
+        *,
+        visibility: ArtifactVisibility | None,
+        github_pat: str | None,
+    ) -> ArtifactVisibility:
+        if visibility:
+            return visibility
+        return "private" if (github_pat or "").strip() else "public"
+
+    def _resolve_location(
+        self,
+        *,
+        username: str,
+        repo: str,
+        visibility: ArtifactVisibility,
+        github_pat: str | None = None,
+    ) -> tuple[str, str, str]:
+        normalized_username = _normalize_segment(username)
+        normalized_repo = _normalize_segment(repo)
+
+        if visibility == "private":
+            if not github_pat:
+                raise ValueError("github_pat is required for private artifact keys.")
+            namespace = self._pat_namespace(github_pat)
+            if not self.r2_private_bucket:
+                raise ValueError("Missing R2_PRIVATE_BUCKET.")
+            return (
+                self.r2_private_bucket,
+                f"private/v1/{namespace}/{normalized_username}/{normalized_repo}.json",
+                f"status:v1:private:{namespace}:{normalized_username}:{normalized_repo}",
+            )
+
+        if not self.r2_public_bucket:
+            raise ValueError("Missing R2_PUBLIC_BUCKET.")
+        return (
+            self.r2_public_bucket,
+            f"public/v1/{normalized_username}/{normalized_repo}.json",
+            f"status:v1:public:{normalized_username}:{normalized_repo}",
+        )
+
+    def _slim_audit(self, audit: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "sessionId": audit.get("sessionId"),
+            "status": audit.get("status"),
+            "stage": audit.get("stage"),
+            "provider": audit.get("provider"),
+            "model": audit.get("model"),
+            "quotaStatus": audit.get("quotaStatus"),
+            "quotaBucket": audit.get("quotaBucket"),
+            "quotaDateUtc": audit.get("quotaDateUtc"),
+            "reservedTokens": audit.get("reservedTokens"),
+            "actualCommittedTokens": audit.get("actualCommittedTokens"),
+            "quotaResetAt": audit.get("quotaResetAt"),
+            "estimatedCost": audit.get("estimatedCost"),
+            "finalCost": audit.get("finalCost"),
+            "graph": audit.get("graph"),
+            "graphAttempts": audit.get("graphAttempts", []) if audit.get("status") == "failed" else [],
+            "stageUsages": [],
+            "validationError": audit.get("validationError"),
+            "failureStage": audit.get("failureStage"),
+            "compilerError": audit.get("compilerError"),
+            "renderError": audit.get("renderError"),
+            "timeline": [],
+            "createdAt": audit.get("createdAt"),
+            "updatedAt": audit.get("updatedAt"),
+        }
+
+    def _get_json_object(self, bucket: str, key: str) -> dict[str, Any] | None:
+        try:
+            response = self._get_s3_client().get_object(Bucket=bucket, Key=key)
+        except ClientError as exc:
+            error_code = exc.response.get("Error", {}).get("Code")
+            if error_code in {"NoSuchKey", "404", "NotFound"}:
+                return None
+            raise
+
+        body = response["Body"].read()
+        if not body:
+            return None
+        return json.loads(body.decode("utf-8"))
+
+    def _put_json_object(self, bucket: str, key: str, payload: dict[str, Any]) -> None:
+        self._get_s3_client().put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=json.dumps(payload).encode("utf-8"),
+            ContentType="application/json",
+        )
+
+    def _clear_failure_summary(self, status_key: str) -> None:
+        self._upstash_command(["DEL", status_key])
+
+    def _write_failure_summary(
+        self,
+        *,
+        username: str,
+        repo: str,
+        visibility: ArtifactVisibility,
+        latest_session_summary: dict[str, Any],
+        github_pat: str | None = None,
+    ) -> None:
+        _bucket, _artifact_key, status_key = self._resolve_location(
+            username=username,
+            repo=repo,
+            visibility=visibility,
+            github_pat=github_pat,
+        )
+        payload = {
+            "version": 1,
+            "visibility": visibility,
+            "username": username,
+            "repo": repo,
+            "latestSessionSummary": latest_session_summary,
+        }
+        self._upstash_command([
+            "SET",
+            status_key,
+            json.dumps(payload),
+            "EX",
+            STATUS_TTL_SECONDS,
+        ])
+
+    def _update_artifact_latest_session_summary(
+        self,
+        *,
+        username: str,
+        repo: str,
+        visibility: ArtifactVisibility,
+        latest_session_summary: dict[str, Any],
+        github_pat: str | None = None,
+    ) -> bool:
+        bucket, artifact_key, _status_key = self._resolve_location(
+            username=username,
+            repo=repo,
+            visibility=visibility,
+            github_pat=github_pat,
+        )
+        artifact = self._get_json_object(bucket, artifact_key)
+        if not artifact:
+            return False
+
+        artifact["latestSessionSummary"] = latest_session_summary
+        self._put_json_object(bucket, artifact_key, artifact)
+        return True
+
+    def _upsert_latest_session_audit_postgres(
+        self,
+        *,
+        username: str,
+        repo: str,
+        audit: dict[str, Any],
+    ) -> None:
         with self._connect() as conn, conn.cursor() as cur:
             cur.execute(
                 """
@@ -55,7 +371,63 @@ class DiagramStateRepository:
                 ),
             )
 
-    def save_successful_diagram_state(
+    def upsert_latest_session_audit(
+        self,
+        *,
+        username: str,
+        repo: str,
+        audit: dict[str, Any],
+        visibility: ArtifactVisibility | None = None,
+        github_pat: str | None = None,
+    ) -> None:
+        resolved_visibility = self._resolve_visibility(
+            visibility=visibility,
+            github_pat=github_pat,
+        )
+
+        if self.cache_backend == "postgres":
+            self._upsert_latest_session_audit_postgres(
+                username=username,
+                repo=repo,
+                audit=audit,
+            )
+            return
+
+        if audit.get("status") == "failed":
+            latest_session_summary = self._slim_audit(audit)
+            artifact_updated = self._update_artifact_latest_session_summary(
+                username=username,
+                repo=repo,
+                visibility=resolved_visibility,
+                github_pat=github_pat,
+                latest_session_summary=latest_session_summary,
+            )
+            if artifact_updated:
+                self._clear_failure_summary(
+                    self._resolve_location(
+                        username=username,
+                        repo=repo,
+                        visibility=resolved_visibility,
+                        github_pat=github_pat,
+                    )[2]
+                )
+            else:
+                self._write_failure_summary(
+                    username=username,
+                    repo=repo,
+                    visibility=resolved_visibility,
+                    github_pat=github_pat,
+                    latest_session_summary=latest_session_summary,
+                )
+
+        if self._should_dual_write_postgres() and audit.get("status") != "running":
+            self._upsert_latest_session_audit_postgres(
+                username=username,
+                repo=repo,
+                audit=audit,
+            )
+
+    def _save_successful_diagram_state_postgres(
         self,
         *,
         username: str,
@@ -115,7 +487,60 @@ class DiagramStateRepository:
                 ),
             )
 
-    def reserve_complimentary_quota(
+    def save_successful_diagram_state(
+        self,
+        *,
+        username: str,
+        repo: str,
+        explanation: str,
+        graph: dict[str, Any],
+        diagram: str,
+        audit: dict[str, Any],
+        used_own_key: bool,
+        visibility: ArtifactVisibility = "public",
+        github_pat: str | None = None,
+    ) -> None:
+        if self._should_use_object_storage():
+            bucket, artifact_key, status_key = self._resolve_location(
+                username=username,
+                repo=repo,
+                visibility=visibility,
+                github_pat=github_pat,
+            )
+            latest_session_summary = self._slim_audit(audit)
+            updated_at = str(audit.get("updatedAt") or audit.get("createdAt") or "")
+            payload = {
+                "version": 1,
+                "visibility": visibility,
+                "username": username,
+                "repo": repo,
+                "diagram": diagram,
+                "explanation": explanation,
+                "graph": graph,
+                "generatedAt": updated_at,
+                "usedOwnKey": used_own_key,
+                "latestSessionSummary": latest_session_summary,
+                "lastSuccessfulAt": updated_at,
+            }
+            self._put_json_object(bucket, artifact_key, payload)
+            self._clear_failure_summary(status_key)
+
+        if self.cache_backend == "postgres" or self._should_dual_write_postgres():
+            self._save_successful_diagram_state_postgres(
+                username=username,
+                repo=repo,
+                explanation=explanation,
+                graph=graph,
+                diagram=diagram,
+                audit=audit,
+                used_own_key=used_own_key,
+            )
+
+    def _quota_key(self, quota_date_utc: str, quota_bucket: str) -> str:
+        pricing_model = quota_bucket.split(":")[1] if ":" in quota_bucket else quota_bucket
+        return f"quota:v1:{quota_date_utc}:{pricing_model}"
+
+    def _reserve_complimentary_quota_postgres(
         self,
         *,
         quota_date_utc: str,
@@ -166,7 +591,7 @@ class DiagramStateRepository:
             )
             return True, used_tokens, next_reserved_tokens
 
-    def finalize_complimentary_quota(
+    def _finalize_complimentary_quota_postgres(
         self,
         *,
         quota_date_utc: str,
@@ -221,3 +646,49 @@ class DiagramStateRepository:
                 ),
             )
             return next_used_tokens, next_reserved_tokens
+
+    def reserve_complimentary_quota(
+        self,
+        *,
+        quota_date_utc: str,
+        quota_bucket: str,
+        token_limit: int,
+        reservation_tokens: int,
+    ) -> tuple[bool, int, int]:
+        if self.quota_backend == "upstash":
+            result = self._upstash_eval(
+                script=RESERVE_QUOTA_SCRIPT,
+                keys=[self._quota_key(quota_date_utc, quota_bucket)],
+                args=[token_limit, reservation_tokens, QUOTA_TTL_SECONDS],
+            )
+            return bool(result[0] == 1), int(result[1] or 0), int(result[2] or 0)
+
+        return self._reserve_complimentary_quota_postgres(
+            quota_date_utc=quota_date_utc,
+            quota_bucket=quota_bucket,
+            token_limit=token_limit,
+            reservation_tokens=reservation_tokens,
+        )
+
+    def finalize_complimentary_quota(
+        self,
+        *,
+        quota_date_utc: str,
+        quota_bucket: str,
+        reservation_tokens: int,
+        committed_tokens: int,
+    ) -> tuple[int, int]:
+        if self.quota_backend == "upstash":
+            result = self._upstash_eval(
+                script=FINALIZE_QUOTA_SCRIPT,
+                keys=[self._quota_key(quota_date_utc, quota_bucket)],
+                args=[reservation_tokens, committed_tokens, QUOTA_TTL_SECONDS],
+            )
+            return int(result[0] or 0), int(result[1] or 0)
+
+        return self._finalize_complimentary_quota_postgres(
+            quota_date_utc=quota_date_utc,
+            quota_bucket=quota_bucket,
+            reservation_tokens=reservation_tokens,
+            committed_tokens=committed_tokens,
+        )

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -44,6 +44,7 @@ class GithubData:
     default_branch: str
     file_tree: str
     readme: str
+    is_private: bool
 
 
 def _should_include_file(path: str) -> bool:
@@ -150,13 +151,13 @@ class GitHubService:
 
         return {"Accept": "application/vnd.github+json"}
 
-    def get_default_branch(self, username: str, repo: str) -> str:
+    def get_repo_metadata(self, username: str, repo: str) -> tuple[str, bool]:
         data = _fetch_json(
             f"https://api.github.com/repos/{username}/{repo}",
             self._get_headers(),
             "Repository not found.",
         )
-        return data.get("default_branch") or "main"
+        return data.get("default_branch") or "main", bool(data.get("private"))
 
     def get_github_file_paths_as_list(self, username: str, repo: str, branch: str) -> str:
         data = _fetch_json(
@@ -191,11 +192,12 @@ class GitHubService:
         return content
 
     def get_github_data(self, username: str, repo: str) -> GithubData:
-        default_branch = self.get_default_branch(username, repo)
+        default_branch, is_private = self.get_repo_metadata(username, repo)
         file_tree = self.get_github_file_paths_as_list(username, repo, default_branch)
         readme = self.get_github_readme(username, repo)
         return GithubData(
             default_branch=default_branch,
             file_tree=file_tree,
             readme=readme,
+            is_private=is_private,
         )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12,<3.13"
 dependencies = [
   "aiohttp==3.13.3",
   "api-analytics==1.2.7",
+  "boto3==1.40.52",
   "fastapi==0.128.8",
   "openai==2.21.0",
   "psycopg[binary]==3.2.10",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -110,6 +110,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.40.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/5a/8ba08c979926326d961e2384d994d789a2eda3ed281bb6cb333b36e92310/boto3-1.40.52.tar.gz", hash = "sha256:96ee720b52be647d8ef5ba92fccfce6b65d6321769430fe6edd10d57ec43c25b", size = 111530 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/d2/879e9787c5263aefc5c88f0dd97cdea29ac01c480dd53c2421de77a493f7/boto3-1.40.52-py3-none-any.whl", hash = "sha256:ecc8c99d3cc96716cdfba62d9c9c6ce0eb98d02494a66690bcc2ec181c1ced67", size = 139345 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.40.76"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/eb/50e2d280589a3c20c3b649bb66262d2b53a25c03262e4cc492048ac7540a/botocore-1.40.76.tar.gz", hash = "sha256:2b16024d68b29b973005adfb5039adfe9099ebe772d40a90ca89f2e165c495dc", size = 14494001 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/6c/522e05388aa6fc66cf8ea46c6b29809a1a6f527ea864998b01ffb368ca36/botocore-1.40.76-py3-none-any.whl", hash = "sha256:fe425d386e48ac64c81cbb4a7181688d813df2e2b4c78b95ebe833c9e868c6f4", size = 14161738 },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -283,6 +311,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "api-analytics" },
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "openai" },
     { name = "psycopg", extra = ["binary"] },
@@ -303,6 +332,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = "==3.13.3" },
     { name = "api-analytics", specifier = "==1.2.7" },
+    { name = "boto3", specifier = "==1.40.52" },
     { name = "fastapi", specifier = "==0.128.8" },
     { name = "openai", specifier = "==2.21.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.10" },
@@ -408,6 +438,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024 },
     { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424 },
     { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818 },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419 },
 ]
 
 [[package]]
@@ -611,6 +650,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -674,6 +725,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738 },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,6 +2,10 @@ import { type Config } from "drizzle-kit";
 
 import { env } from "~/env";
 
+if (!env.POSTGRES_URL) {
+  throw new Error("Missing POSTGRES_URL for Drizzle commands.");
+}
+
 export default {
   schema: "./src/server/db/schema.ts",
   dialect: "postgresql",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "preview": "next build && next start",
     "start": "next start",
     "start:backend": "cd backend && ENVIRONMENT=production uv run --no-dev uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}",
+    "backfill:public-cache": "node scripts/backfill-public-cache-to-r2.mjs",
+    "backfill:public-cache:loop": "node scripts/backfill-public-cache-loop.mjs",
+    "backfill:public-cache:daemon": "node scripts/backfill-public-cache-daemon.mjs",
+    "backfill:public-cache:status": "node scripts/backfill-public-cache-status.mjs",
     "quota:today": "node scripts/complimentary-quota-today.mjs",
     "test": "vitest run",
     "test:backend": "cd backend && uv run pytest -q",
@@ -26,6 +30,7 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.913.0",
     "@mermaid-js/layout-elk": "^0.2.1",
     "@neondatabase/serverless": "^1.0.2",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.913.0
+        version: 3.1019.0
       '@mermaid-js/layout-elk':
         specifier: ^0.2.1
         version: 0.2.1(mermaid@11.12.3)
@@ -177,6 +180,165 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1019.0':
+    resolution: {integrity: sha512-0pb9x7PPhS4oEi4c0rL3vzQQoXA4cWKtPuGga/UfVYLZ68yrqdq0NDKg0fr55qzdhNvWFCpmGx73g9Iyy03kkA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.25':
+    resolution: {integrity: sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.5':
+    resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.23':
+    resolution: {integrity: sha512-EamaclJcCEaPHp6wiVknNMM2RlsPMjAHSsYSFLNENBM8Wz92QPc6cOn3dif6vPDQt0Oo4IEghDy3NMDCzY/IvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.25':
+    resolution: {integrity: sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.26':
+    resolution: {integrity: sha512-xKxEAMuP6GYx2y5GET+d3aGEroax3AgGfwBE65EQAUe090lzyJ/RzxPX9s8v7Z6qAk0XwfQl+LrmH05X7YvTeg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.26':
+    resolution: {integrity: sha512-EFcM8RM3TUxnZOfMJo++3PnyxFu1fL/huzmn3Vh+8IWRgqZawUD3cRwwOr+/4bE9DpyHaLOWFAjY0lfK5X9ZkQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.27':
+    resolution: {integrity: sha512-jXpxSolfFnPVj6GCTtx3xIdWNoDR7hYC/0SbetGZxOC9UnNmipHeX1k6spVstf7eWJrMhXNQEgXC0pD1r5tXIg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.23':
+    resolution: {integrity: sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.26':
+    resolution: {integrity: sha512-c6ghvRb6gTlMznWhGxn/bpVCcp0HRaz4DobGVD9kI4vwHq186nU2xN/S7QGkm0lo0H2jQU8+dgpUFLxfTcwCOg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.26':
+    resolution: {integrity: sha512-cXcS3+XD3iwhoXkM44AmxjmbcKueoLCINr1e+IceMmCySda5ysNIfiGBGe9qn5EMiQ9Jd7pP0AGFtcd6OV3Lvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.8':
+    resolution: {integrity: sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.8':
+    resolution: {integrity: sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.5':
+    resolution: {integrity: sha512-SPSvF0G1t8m8CcB0L+ClNFszzQOvXaxmRj25oRWDf6aU+TuN2PXPFAJ9A6lt1IvX4oGAqqbTdMPTYs/SSHUYYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.8':
+    resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.8':
+    resolution: {integrity: sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.8':
+    resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
+    resolution: {integrity: sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.26':
+    resolution: {integrity: sha512-5q7UGSTtt7/KF0Os8wj2VZtlLxeWJVb0e2eDrDJlWot2EIxUNKDDMPFq/FowUqrwZ40rO2bu6BypxaKNvQhI+g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.8':
+    resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.26':
+    resolution: {integrity: sha512-AilFIh4rI/2hKyyGN6XrB0yN96W2o7e7wyrPWCM6QjZM1mcC/pVkW3IWWRvuBWMpVP8Fg+rMpbzeLQ6dTM4gig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.996.16':
+    resolution: {integrity: sha512-L7Qzoj/qQU1cL5GnYLQP5LbI+wlLCLoINvcykR3htKcQ4tzrPf2DOs72x933BM7oArYj1SKrkb2lGlsJHIic3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.10':
+    resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.14':
+    resolution: {integrity: sha512-4nZSrBr1NO+48HCM/6BRU8mnRjuHZjcpziCvLXZk5QVftwWz5Mxqbhwdz4xf7WW88buaTB8uRO2MHklSX1m0vg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1019.0':
+    resolution: {integrity: sha512-OF+2RfRmUKyjzrRWlDcyju3RBsuqcrYDQ8TwrJg8efcOotMzuZN4U9mpVTIdATpmEc4lWNZBMSjPzrGm6JPnAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.6':
+    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.5':
+    resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.8':
+    resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
+
+  '@aws-sdk/util-user-agent-node@3.973.12':
+    resolution: {integrity: sha512-8phW0TS8ntENJgDcFewYT/Q8dOmarpvSxEjATu2GUBAutiHr++oEGCiBUwxslCMNvwW2cAPZNT53S/ym8zm/gg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.16':
+    resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1651,6 +1813,222 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@smithy/abort-controller@4.2.12':
+    resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.13':
+    resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.12':
+    resolution: {integrity: sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.12':
+    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.12':
+    resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.12':
+    resolution: {integrity: sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.12':
+    resolution: {integrity: sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.12':
+    resolution: {integrity: sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.12':
+    resolution: {integrity: sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.15':
+    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.13':
+    resolution: {integrity: sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.12':
+    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.12':
+    resolution: {integrity: sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.12':
+    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.12':
+    resolution: {integrity: sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.12':
+    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.27':
+    resolution: {integrity: sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.44':
+    resolution: {integrity: sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.15':
+    resolution: {integrity: sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.12':
+    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.12':
+    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.5.0':
+    resolution: {integrity: sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.12':
+    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.12':
+    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.12':
+    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.12':
+    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.12':
+    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.7':
+    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.12':
+    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.7':
+    resolution: {integrity: sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.13.1':
+    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.12':
+    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.43':
+    resolution: {integrity: sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.47':
+    resolution: {integrity: sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.3.3':
+    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.12':
+    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.12':
+    resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.20':
+    resolution: {integrity: sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.13':
+    resolution: {integrity: sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2244,6 +2622,9 @@ packages:
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -2920,6 +3301,13 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3591,6 +3979,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.2.0:
+    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -4002,6 +4394,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.2.2:
+    resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4389,6 +4784,450 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1019.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/credential-provider-node': 3.972.27
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.8
+      '@aws-sdk/middleware-expect-continue': 3.972.8
+      '@aws-sdk/middleware-flexible-checksums': 3.974.5
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-location-constraint': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-sdk-s3': 3.972.26
+      '@aws-sdk/middleware-ssec': 3.972.8
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/signature-v4-multi-region': 3.996.14
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.12
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.12
+      '@smithy/eventstream-serde-browser': 4.2.12
+      '@smithy/eventstream-serde-config-resolver': 4.3.12
+      '@smithy/eventstream-serde-node': 4.2.12
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-blob-browser': 4.2.13
+      '@smithy/hash-node': 4.2.12
+      '@smithy/hash-stream-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/md5-js': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.27
+      '@smithy/middleware-retry': 4.4.44
+      '@smithy/middleware-serde': 4.2.15
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.5.0
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.43
+      '@smithy/util-defaults-mode-node': 4.2.47
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/util-stream': 4.5.20
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.2.13
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.25':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/xml-builder': 3.972.16
+      '@smithy/core': 3.23.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.5':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.23':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.25':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/types': 3.973.6
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.5.0
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.20
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.26':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/credential-provider-env': 3.972.23
+      '@aws-sdk/credential-provider-http': 3.972.25
+      '@aws-sdk/credential-provider-login': 3.972.26
+      '@aws-sdk/credential-provider-process': 3.972.23
+      '@aws-sdk/credential-provider-sso': 3.972.26
+      '@aws-sdk/credential-provider-web-identity': 3.972.26
+      '@aws-sdk/nested-clients': 3.996.16
+      '@aws-sdk/types': 3.973.6
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.26':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.16
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.27':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.23
+      '@aws-sdk/credential-provider-http': 3.972.25
+      '@aws-sdk/credential-provider-ini': 3.972.26
+      '@aws-sdk/credential-provider-process': 3.972.23
+      '@aws-sdk/credential-provider-sso': 3.972.26
+      '@aws-sdk/credential-provider-web-identity': 3.972.26
+      '@aws-sdk/types': 3.973.6
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.23':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.26':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.16
+      '@aws-sdk/token-providers': 3.1019.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.26':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.16
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.5':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/crc64-nvme': 3.972.5
+      '@aws-sdk/types': 3.973.6
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.20
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.26':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.20
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.26':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@smithy/core': 3.23.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-retry': 4.2.12
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.996.16':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.12
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.12
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.27
+      '@smithy/middleware-retry': 4.4.44
+      '@smithy/middleware-serde': 4.2.15
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.5.0
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.43
+      '@smithy/util-defaults-mode-node': 4.2.47
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.14':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.26
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1019.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/nested-clients': 3.996.16
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.6':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.5':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-endpoints': 3.3.3
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.12':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/types': 3.973.6
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.16':
+    dependencies:
+      '@smithy/types': 4.13.1
+      fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5495,6 +6334,345 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@smithy/abort-controller@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    dependencies:
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.13':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.12':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.20
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.12':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.12':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.13.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.12':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.12':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.12':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.15':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.13':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.12':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.27':
+    dependencies:
+      '@smithy/core': 3.23.12
+      '@smithy/middleware-serde': 4.2.15
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-middleware': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.44':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.15':
+    dependencies:
+      '@smithy/core': 3.23.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.12':
+    dependencies:
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.5.0':
+    dependencies:
+      '@smithy/abort-controller': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+
+  '@smithy/shared-ini-file-loader@4.4.7':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.12':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.7':
+    dependencies:
+      '@smithy/core': 3.23.12
+      '@smithy/middleware-endpoint': 4.4.27
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.20
+      tslib: 2.8.1
+
+  '@smithy/types@4.13.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.12':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.43':
+    dependencies:
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.47':
+    dependencies:
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.3.3':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.12':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.20':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.5.0
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.13':
+    dependencies:
+      '@smithy/abort-controller': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -6091,6 +7269,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.9.19: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -6926,6 +8106,16 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-xml-builder@1.1.4:
+    dependencies:
+      path-expression-matcher: 1.2.0
+
+  fast-xml-parser@5.5.8:
+    dependencies:
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.2.0
+      strnum: 2.2.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -7595,6 +8785,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.2.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -8062,6 +9254,8 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  strnum@2.2.2: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:

--- a/scripts/backfill-public-cache-daemon.mjs
+++ b/scripts/backfill-public-cache-daemon.mjs
@@ -1,0 +1,97 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function parseArgs(argv) {
+  const parsed = {
+    batchSize: 2000,
+    concurrency: 8,
+    maxBatchesPerRun: 3,
+    stateFile: ".cache/backfill-public-cache-state.json",
+    startCursor: undefined,
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith("--batch-size=")) {
+      parsed.batchSize =
+        Number.parseInt(arg.slice("--batch-size=".length), 10) || parsed.batchSize;
+      continue;
+    }
+    if (arg.startsWith("--concurrency=")) {
+      parsed.concurrency =
+        Number.parseInt(arg.slice("--concurrency=".length), 10) || parsed.concurrency;
+      continue;
+    }
+    if (arg.startsWith("--max-batches-per-run=")) {
+      parsed.maxBatchesPerRun =
+        Number.parseInt(arg.slice("--max-batches-per-run=".length), 10) ||
+        parsed.maxBatchesPerRun;
+      continue;
+    }
+    if (arg.startsWith("--state-file=")) {
+      parsed.stateFile = arg.slice("--state-file=".length) || parsed.stateFile;
+      continue;
+    }
+    if (arg.startsWith("--cursor=")) {
+      parsed.startCursor = arg.slice("--cursor=".length) || undefined;
+    }
+  }
+
+  return parsed;
+}
+
+function loadState(stateFile) {
+  try {
+    return JSON.parse(readFileSync(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+const args = parseArgs(process.argv.slice(2));
+const stateFile = resolve(args.stateFile);
+let cursor = args.startCursor;
+
+for (;;) {
+  const commandArgs = [
+    "scripts/backfill-public-cache-loop.mjs",
+    `--batch-size=${args.batchSize}`,
+    `--concurrency=${args.concurrency}`,
+    `--max-batches=${args.maxBatchesPerRun}`,
+    `--state-file=${stateFile}`,
+  ];
+  if (cursor) {
+    commandArgs.push(`--cursor=${cursor}`);
+  }
+
+  const result = spawnSync("node", commandArgs, {
+    stdio: "inherit",
+    env: process.env,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Backfill daemon failed with exit code ${result.status ?? "unknown"}.`);
+  }
+
+  const state = loadState(stateFile);
+  if (!state?.nextCursor) {
+    console.log("Backfill daemon exhausted.");
+    break;
+  }
+
+  cursor = state.nextCursor;
+
+  if (state.haltedReason !== "github_rate_limit" || !state.rateResetAt) {
+    console.log(`Backfill daemon continuing from ${state.nextCursor}.`);
+    continue;
+  }
+
+  const waitMs = Math.max(new Date(state.rateResetAt).getTime() - Date.now() + 5_000, 5_000);
+  console.log(`Backfill daemon sleeping until ${state.rateResetAt} (${Math.ceil(waitMs / 1000)}s).`);
+  await sleep(waitMs);
+}

--- a/scripts/backfill-public-cache-loop.mjs
+++ b/scripts/backfill-public-cache-loop.mjs
@@ -1,0 +1,206 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+function parseArgs(argv) {
+  const parsed = {
+    batchSize: 2000,
+    concurrency: 8,
+    maxBatches: Infinity,
+    stateFile: ".cache/backfill-public-cache-state.json",
+    startCursor: undefined,
+    dryRun: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--dry-run") {
+      parsed.dryRun = true;
+      continue;
+    }
+    if (arg.startsWith("--batch-size=")) {
+      parsed.batchSize =
+        Number.parseInt(arg.slice("--batch-size=".length), 10) || parsed.batchSize;
+      continue;
+    }
+    if (arg.startsWith("--concurrency=")) {
+      parsed.concurrency =
+        Number.parseInt(arg.slice("--concurrency=".length), 10) || parsed.concurrency;
+      continue;
+    }
+    if (arg.startsWith("--max-batches=")) {
+      const value = Number.parseInt(arg.slice("--max-batches=".length), 10);
+      parsed.maxBatches = Number.isFinite(value) && value > 0 ? value : parsed.maxBatches;
+      continue;
+    }
+    if (arg.startsWith("--state-file=")) {
+      parsed.stateFile = arg.slice("--state-file=".length) || parsed.stateFile;
+      continue;
+    }
+    if (arg.startsWith("--cursor=")) {
+      parsed.startCursor = arg.slice("--cursor=".length) || undefined;
+    }
+  }
+
+  return parsed;
+}
+
+function loadState(stateFile) {
+  try {
+    return JSON.parse(readFileSync(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function saveState(stateFile, payload) {
+  mkdirSync(dirname(stateFile), { recursive: true });
+  writeFileSync(stateFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function extractSummary(stdout) {
+  const lines = stdout.split(/\r?\n/);
+  const summary = {
+    skipReasons: {},
+  };
+  const readValue = (line, prefix) => line.slice(prefix.length).trim();
+
+  for (const line of lines) {
+    if (line.startsWith("Processed:")) {
+      summary.processed = Number.parseInt(readValue(line, "Processed:").replaceAll(",", ""), 10);
+    } else if (line.startsWith("Uploaded:")) {
+      summary.uploaded = Number.parseInt(readValue(line, "Uploaded:").replaceAll(",", ""), 10);
+    } else if (line.startsWith("Skipped:")) {
+      summary.skipped = Number.parseInt(readValue(line, "Skipped:").replaceAll(",", ""), 10);
+    } else if (line.startsWith("Errors:")) {
+      summary.errors = Number.parseInt(readValue(line, "Errors:").replaceAll(",", ""), 10);
+    } else if (line.startsWith("Next cursor:")) {
+      summary.nextCursor = readValue(line, "Next cursor:") || null;
+    } else if (line.startsWith("Rate limited:")) {
+      summary.rateLimited = readValue(line, "Rate limited:") === "yes";
+    } else if (line.startsWith("Rate reset at:")) {
+      summary.rateResetAt = readValue(line, "Rate reset at:") || null;
+    } else if (line.startsWith("Retry after:")) {
+      summary.retryAfter = Number.parseInt(readValue(line, "Retry after:"), 10);
+    } else if (line.startsWith("Skip ")) {
+      const match = /^Skip\s+(.+?):\s+([\d,]+)$/.exec(line.trim());
+      if (match) {
+        summary.skipReasons[match[1]] = Number.parseInt(
+          match[2].replaceAll(",", ""),
+          10,
+        );
+      }
+    }
+  }
+
+  return summary;
+}
+
+function mergeCounts(base = {}, delta = {}) {
+  const merged = { ...base };
+  for (const [key, value] of Object.entries(delta)) {
+    merged[key] = (merged[key] ?? 0) + value;
+  }
+  return merged;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const stateFile = resolve(args.stateFile);
+const existingState = loadState(stateFile);
+let cursor = args.startCursor ?? existingState?.nextCursor;
+let totalProcessed = existingState?.totals?.processed ?? 0;
+let totalUploaded = existingState?.totals?.uploaded ?? 0;
+let totalSkipped = existingState?.totals?.skipped ?? 0;
+let totalErrors = existingState?.totals?.errors ?? 0;
+let totalSkipReasons = existingState?.totals?.skipReasons ?? {};
+
+for (let batchNumber = 1; batchNumber <= args.maxBatches; batchNumber += 1) {
+  const commandArgs = [
+    "scripts/backfill-public-cache-to-r2.mjs",
+    `--limit=${args.batchSize}`,
+    `--concurrency=${args.concurrency}`,
+  ];
+
+  if (cursor) {
+    commandArgs.push(`--cursor=${cursor}`);
+  }
+  if (args.dryRun) {
+    commandArgs.push("--dry-run");
+  }
+
+  console.log(
+    `batch=${batchNumber} cursor=${cursor ?? "<start>"} size=${args.batchSize} concurrency=${args.concurrency}`,
+  );
+
+  const result = spawnSync("node", commandArgs, {
+    stdio: "pipe",
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  if (result.status !== 0) {
+    const summary = extractSummary(result.stdout ?? "");
+    if (summary.rateLimited) {
+      saveState(stateFile, {
+        updatedAt: new Date().toISOString(),
+        batchNumber,
+        nextCursor: summary.nextCursor ?? cursor ?? null,
+        haltedReason: "github_rate_limit",
+        lastBatch: summary,
+        totals: {
+          processed: totalProcessed + (summary.processed ?? 0),
+          uploaded: totalUploaded + (summary.uploaded ?? 0),
+          skipped: totalSkipped + (summary.skipped ?? 0),
+          errors: totalErrors + (summary.errors ?? 0),
+          skipReasons: mergeCounts(totalSkipReasons, summary.skipReasons),
+        },
+      });
+      console.log("Backfill paused for GitHub rate limit.");
+      break;
+    }
+
+    throw new Error(`Backfill batch ${batchNumber} failed with exit code ${result.status ?? "unknown"}.`);
+  }
+
+  const summary = extractSummary(result.stdout ?? "");
+  totalProcessed += summary.processed ?? 0;
+  totalUploaded += summary.uploaded ?? 0;
+  totalSkipped += summary.skipped ?? 0;
+  totalErrors += summary.errors ?? 0;
+  totalSkipReasons = mergeCounts(totalSkipReasons, summary.skipReasons);
+
+  saveState(stateFile, {
+    updatedAt: new Date().toISOString(),
+    batchNumber,
+    nextCursor: summary.nextCursor ?? null,
+    haltedReason: summary.rateLimited ? "github_rate_limit" : null,
+    rateResetAt: summary.rateResetAt ?? null,
+    retryAfter: summary.retryAfter ?? null,
+    lastBatch: summary,
+    totals: {
+      processed: totalProcessed,
+      uploaded: totalUploaded,
+      skipped: totalSkipped,
+      errors: totalErrors,
+      skipReasons: totalSkipReasons,
+    },
+  });
+
+  if (!summary.nextCursor || (summary.processed ?? 0) === 0) {
+    console.log("Backfill exhausted.");
+    break;
+  }
+
+  if (summary.rateLimited) {
+    console.log("Backfill paused for GitHub rate limit.");
+    break;
+  }
+
+  cursor = summary.nextCursor;
+}

--- a/scripts/backfill-public-cache-status.mjs
+++ b/scripts/backfill-public-cache-status.mjs
@@ -1,0 +1,145 @@
+import { config } from "dotenv";
+import postgres from "postgres";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { execSync } from "node:child_process";
+
+config({ path: ".env" });
+
+function parseArgs(argv) {
+  const parsed = {
+    stateFile: "/tmp/gitdiagram-backfill-state.json",
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith("--state-file=")) {
+      parsed.stateFile = arg.slice("--state-file=".length) || parsed.stateFile;
+    }
+  }
+
+  return parsed;
+}
+
+function loadState(stateFile) {
+  try {
+    return JSON.parse(readFileSync(stateFile, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readEnv(name) {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function readEnvList(name) {
+  const value = readEnv(name);
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return "0s";
+  }
+
+  const totalSeconds = Math.ceil(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts = [];
+  if (hours) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes) {
+    parts.push(`${minutes}m`);
+  }
+  if (seconds && !hours) {
+    parts.push(`${seconds}s`);
+  }
+  return parts.join(" ");
+}
+
+function getProcessSummary() {
+  try {
+    return execSync(
+      "ps -Ao pid,etime,command | rg 'backfill-public-cache-daemon|caffeinate -dimsu' -n -S",
+      { encoding: "utf8" },
+    ).trim();
+  } catch {
+    return "";
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const state = loadState(resolve(args.stateFile));
+const databaseUrl = process.env.POSTGRES_URL?.trim();
+
+let totalCandidates = null;
+if (databaseUrl) {
+  const sql = postgres(databaseUrl);
+  const rows = await sql.unsafe(
+    "select count(*)::int as count from gitdiagram_diagram_cache where coalesce(diagram, '') <> ''",
+  );
+  totalCandidates = rows[0]?.count ?? null;
+  await sql.end();
+}
+
+const processed = state?.totals?.processed ?? 0;
+const uploaded = state?.totals?.uploaded ?? 0;
+const skipped = state?.totals?.skipped ?? 0;
+const errors = state?.totals?.errors ?? 0;
+const totalSkipReasons = state?.totals?.skipReasons ?? {};
+const lastBatchSkipReasons = state?.lastBatch?.skipReasons ?? {};
+const remaining = totalCandidates === null ? null : Math.max(totalCandidates - processed, 0);
+const rowsPerHour = 5000;
+const etaMs = remaining === null ? null : (remaining / rowsPerHour) * 60 * 60 * 1000;
+const authSourceCount =
+  (readEnv("GITHUB_CLIENT_ID") && readEnv("GITHUB_PRIVATE_KEY") && readEnv("GITHUB_INSTALLATION_ID")
+    ? 1
+    : 0) +
+  (readEnv("GITHUB_PAT") ? 1 : 0) +
+  readEnvList("GITHUB_PATS").length;
+const maxRowsPerHour = Math.max(authSourceCount, 1) * rowsPerHour;
+const maxEtaMs = remaining === null ? null : (remaining / maxRowsPerHour) * 60 * 60 * 1000;
+const resetAt = state?.rateResetAt ? new Date(state.rateResetAt) : null;
+const resetInMs = resetAt ? resetAt.getTime() - Date.now() : null;
+
+console.log(`state_file=${resolve(args.stateFile)}`);
+console.log(`daemon=${getProcessSummary() ? "running" : "not_running"}`);
+if (getProcessSummary()) {
+  console.log(getProcessSummary());
+}
+console.log(`cursor=${state?.nextCursor ?? "unknown"}`);
+console.log(`halted_reason=${state?.haltedReason ?? "none"}`);
+console.log(`updated_at=${state?.updatedAt ?? "unknown"}`);
+console.log(`processed=${processed}`);
+console.log(`uploaded=${uploaded}`);
+console.log(`skipped=${skipped}`);
+console.log(`errors=${errors}`);
+for (const [reason, count] of Object.entries(totalSkipReasons)) {
+  console.log(`skip_total_${reason}=${count}`);
+}
+for (const [reason, count] of Object.entries(lastBatchSkipReasons)) {
+  console.log(`skip_last_batch_${reason}=${count}`);
+}
+if (totalCandidates !== null) {
+  console.log(`total_candidates=${totalCandidates}`);
+  console.log(`remaining_candidates=${remaining}`);
+  console.log(`progress=${((processed / totalCandidates) * 100).toFixed(2)}%`);
+  console.log(`rough_eta_single_bucket=${formatDuration(etaMs)}`);
+  console.log(`auth_source_count=${authSourceCount}`);
+  console.log(`max_auth_limited_rate_per_hour=${maxRowsPerHour}`);
+  console.log(`rough_eta_max_capacity=${formatDuration(maxEtaMs)}`);
+}
+if (resetAt) {
+  console.log(`github_rate_reset_at=${resetAt.toISOString()}`);
+  console.log(`github_rate_reset_in=${formatDuration(resetInMs)}`);
+}

--- a/scripts/backfill-public-cache-to-r2.mjs
+++ b/scripts/backfill-public-cache-to-r2.mjs
@@ -1,0 +1,679 @@
+import { createRequire } from "node:module";
+import { createSign } from "node:crypto";
+
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { config } from "dotenv";
+import DOMPurify from "dompurify";
+import postgres from "postgres";
+
+config({ path: ".env" });
+
+const require = createRequire(import.meta.url);
+
+function readEnv(name) {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function readEnvList(name) {
+  const value = readEnv(name);
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    dryRun: false,
+    limit: 250,
+    cursor: undefined,
+    concurrency: 4,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--dry-run") {
+      parsed.dryRun = true;
+      continue;
+    }
+    if (arg.startsWith("--limit=")) {
+      parsed.limit = Number.parseInt(arg.slice("--limit=".length), 10) || parsed.limit;
+      continue;
+    }
+    if (arg.startsWith("--cursor=")) {
+      parsed.cursor = arg.slice("--cursor=".length) || undefined;
+      continue;
+    }
+    if (arg.startsWith("--concurrency=")) {
+      parsed.concurrency =
+        Number.parseInt(arg.slice("--concurrency=".length), 10) || parsed.concurrency;
+    }
+  }
+
+  return parsed;
+}
+
+function getS3Client() {
+  return new S3Client({
+    region: "auto",
+    endpoint: `https://${readEnv("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: readEnv("R2_ACCESS_KEY_ID"),
+      secretAccessKey: readEnv("R2_SECRET_ACCESS_KEY"),
+    },
+  });
+}
+
+function normalizeSegment(value) {
+  return encodeURIComponent(value.trim().toLowerCase());
+}
+
+function artifactKey(username, repo) {
+  return `public/v1/${normalizeSegment(username)}/${normalizeSegment(repo)}.json`;
+}
+
+function normalizeTimestamp(value) {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
+}
+
+function buildLegacySessionSummary(row) {
+  const timestamp =
+    normalizeTimestamp(row.lastSuccessfulAt) ??
+    normalizeTimestamp(row.updatedAt) ??
+    normalizeTimestamp(row.createdAt) ??
+    new Date().toISOString();
+
+  return {
+    sessionId: `legacy:${row.username}/${row.repo}`,
+    status: "succeeded",
+    stage: "complete",
+    provider: row.latestSessionProvider ?? "legacy",
+    model: row.latestSessionModel ?? "legacy",
+    graph: row.graph ?? null,
+    graphAttempts: [],
+    stageUsages: [],
+    timeline: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+function toStoredSessionSummary(audit) {
+  if (!audit) {
+    return null;
+  }
+
+  return {
+    sessionId: audit.sessionId,
+    status: audit.status,
+    stage: audit.stage,
+    provider: audit.provider,
+    model: audit.model,
+    quotaStatus: audit.quotaStatus,
+    quotaBucket: audit.quotaBucket,
+    quotaDateUtc: audit.quotaDateUtc,
+    reservedTokens: audit.reservedTokens,
+    actualCommittedTokens: audit.actualCommittedTokens,
+    quotaResetAt: audit.quotaResetAt,
+    estimatedCost: audit.estimatedCost,
+    finalCost: audit.finalCost,
+    graph: audit.graph ?? null,
+    graphAttempts: audit.status === "failed" ? audit.graphAttempts ?? [] : [],
+    stageUsages: [],
+    validationError: audit.validationError,
+    failureStage: audit.failureStage,
+    compilerError: audit.compilerError,
+    renderError: audit.renderError,
+    timeline: [],
+    createdAt: audit.createdAt,
+    updatedAt: audit.updatedAt,
+  };
+}
+
+function getStoredSessionSummary(row) {
+  return toStoredSessionSummary(row.latestSessionAudit) ?? buildLegacySessionSummary(row);
+}
+
+function getArtifactTimestamp(row) {
+  return (
+    normalizeTimestamp(row.lastSuccessfulAt) ??
+    normalizeTimestamp(row.updatedAt) ??
+    normalizeTimestamp(row.createdAt)
+  );
+}
+
+class GithubRateLimitError extends Error {
+  constructor({ username, repo, resetAt, retryAfter, message, authSource }) {
+    super(message);
+    this.name = "GithubRateLimitError";
+    this.username = username;
+    this.repo = repo;
+    this.resetAt = resetAt ?? null;
+    this.retryAfter = retryAfter ?? null;
+    this.authSource = authSource ?? "unknown";
+  }
+}
+
+const githubAuthCooldowns = new Map();
+
+function getAuthCooldown(source) {
+  const cooldown = githubAuthCooldowns.get(source);
+  if (!cooldown) {
+    return null;
+  }
+  if (cooldown.until <= Date.now()) {
+    githubAuthCooldowns.delete(source);
+    return null;
+  }
+  return cooldown;
+}
+
+function setAuthCooldown(source, error) {
+  if (!source || source === "unknown") {
+    return;
+  }
+
+  const resetMs = error.resetAt ? new Date(error.resetAt).getTime() : null;
+  const retryAfterMs =
+    typeof error.retryAfter === "number" && Number.isFinite(error.retryAfter)
+      ? Date.now() + error.retryAfter * 1000
+      : null;
+  const until = Math.max(resetMs ?? 0, retryAfterMs ?? 0, Date.now() + 60_000);
+  githubAuthCooldowns.set(source, {
+    until,
+    resetAt: error.resetAt ?? (until ? new Date(until).toISOString() : null),
+    retryAfter: error.retryAfter ?? null,
+  });
+}
+
+let mermaidInstance = null;
+let mermaidInitialized = false;
+let domPurifyPatched = false;
+
+function ensureDomPurifyPatched() {
+  if (domPurifyPatched) {
+    return;
+  }
+
+  try {
+    const domPurify = DOMPurify;
+    if (typeof domPurify === "function" && typeof domPurify.sanitize !== "function") {
+      const { JSDOM } = require("jsdom");
+      const domWindow = new JSDOM("<!doctype html><html><body></body></html>").window;
+      const domPurifyInstance = domPurify(domWindow);
+      Object.assign(domPurify, domPurifyInstance);
+    }
+  } catch {
+    // Best effort patch.
+  } finally {
+    domPurifyPatched = true;
+  }
+}
+
+async function getMermaid() {
+  if (mermaidInstance) {
+    return mermaidInstance;
+  }
+
+  ensureDomPurifyPatched();
+  const mermaidModule = await import("mermaid");
+  mermaidInstance = mermaidModule.default;
+  return mermaidInstance;
+}
+
+async function validateMermaidSyntax(diagram) {
+  const mermaid = await getMermaid();
+  if (!mermaidInitialized) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "loose",
+    });
+    mermaidInitialized = true;
+  }
+
+  try {
+    await mermaid.parse(diagram);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchRepoMetadataWithHeaders(username, repo, headers, authSource) {
+  const response = await fetch(`https://api.github.com/repos/${username}/${repo}`, {
+    headers,
+    cache: "no-store",
+  });
+  let responseText = null;
+
+  if (response.status === 404) {
+    return null;
+  }
+  if (response.status === 403 || response.status === 429) {
+    responseText = await response.text();
+    const lowerText = responseText.toLowerCase();
+    const resetHeader = response.headers.get("x-ratelimit-reset");
+    const retryAfter = response.headers.get("retry-after");
+    if (
+      lowerText.includes("rate limit") ||
+      response.headers.get("x-ratelimit-remaining") === "0" ||
+      retryAfter
+    ) {
+      throw new GithubRateLimitError({
+        username,
+        repo,
+        resetAt: resetHeader
+          ? new Date(Number.parseInt(resetHeader, 10) * 1000).toISOString()
+          : null,
+        retryAfter: retryAfter ? Number.parseInt(retryAfter, 10) : null,
+        message: `GitHub repo lookup rate limited for ${username}/${repo} via ${authSource} (${response.status})`,
+        authSource,
+      });
+    }
+  }
+  if (!response.ok) {
+    responseText ??= await response.text();
+    throw new Error(
+      `GitHub repo lookup failed for ${username}/${repo} (${response.status}): ${responseText}`,
+    );
+  }
+
+  return response.json();
+}
+
+async function fetchRepoMetadata(username, repo, githubPat) {
+  const authAttempts = await createGithubAuthAttempts(githubPat);
+  let rateLimitError = null;
+
+  for (const attempt of authAttempts) {
+    try {
+      return await fetchRepoMetadataWithHeaders(
+        username,
+        repo,
+        attempt.headers,
+        attempt.source,
+      );
+    } catch (error) {
+      if (error instanceof GithubRateLimitError) {
+        setAuthCooldown(attempt.source, error);
+        rateLimitError ??= error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  if (rateLimitError) {
+    throw rateLimitError;
+  }
+
+  throw new Error(`GitHub repo lookup could not be authenticated for ${username}/${repo}.`);
+}
+
+let githubInstallationToken = null;
+let githubInstallationTokenExpiresAt = 0;
+
+function createGithubJwt() {
+  const clientId = readEnv("GITHUB_CLIENT_ID");
+  const privateKey = readEnv("GITHUB_PRIVATE_KEY")?.replace(/\\n/g, "\n");
+
+  if (!clientId || !privateKey) {
+    return null;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" }),
+  ).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      iat: now,
+      exp: now + 10 * 60,
+      iss: clientId,
+    }),
+  ).toString("base64url");
+
+  const signer = createSign("RSA-SHA256");
+  signer.update(`${header}.${payload}`);
+  signer.end();
+  const signature = signer.sign(privateKey, "base64url");
+  return `${header}.${payload}.${signature}`;
+}
+
+async function getGithubInstallationToken() {
+  if (
+    githubInstallationToken &&
+    githubInstallationTokenExpiresAt > Date.now() + 60_000
+  ) {
+    return githubInstallationToken;
+  }
+
+  const installationId = readEnv("GITHUB_INSTALLATION_ID");
+  const jwt = createGithubJwt();
+  if (!installationId || !jwt) {
+    return null;
+  }
+
+  const response = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub installation token request failed (${response.status}): ${await response.text()}`,
+    );
+  }
+
+  const payload = await response.json();
+  githubInstallationToken = payload.token ?? null;
+  githubInstallationTokenExpiresAt = payload.expires_at
+    ? new Date(payload.expires_at).getTime()
+    : Date.now() + 50 * 60 * 1000;
+  return githubInstallationToken;
+}
+
+function getGithubPersonalAccessTokens() {
+  const tokens = [];
+  const seen = new Set();
+
+  for (const token of [readEnv("GITHUB_PAT"), ...readEnvList("GITHUB_PATS")]) {
+    if (!token || seen.has(token)) {
+      continue;
+    }
+    seen.add(token);
+    tokens.push(token);
+  }
+
+  return tokens;
+}
+
+async function createGithubAuthAttempts(githubPat) {
+  const attempts = [];
+  const addAttempt = (attempt) => {
+    const cooldown = getAuthCooldown(attempt.source);
+    if (cooldown) {
+      return;
+    }
+    attempts.push(attempt);
+  };
+  const installationToken = await getGithubInstallationToken();
+  if (installationToken) {
+    addAttempt({
+      source: "app_installation",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${installationToken}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  }
+
+  const personalAccessTokens = githubPat
+    ? [githubPat, ...getGithubPersonalAccessTokens()]
+    : getGithubPersonalAccessTokens();
+
+  for (const [index, token] of personalAccessTokens.entries()) {
+    addAttempt({
+      source: `personal_access_token_${index + 1}`,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `token ${token}`,
+      },
+    });
+  }
+
+  if (attempts.length === 0) {
+    addAttempt({
+      source: "unauthenticated",
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    });
+  }
+
+  return attempts;
+}
+
+async function getExistingArtifact(client, bucket, key) {
+  try {
+    const response = await client.send(
+      new GetObjectCommand({
+        Bucket: bucket,
+        Key: key,
+      }),
+    );
+    const body = await response.Body?.transformToString();
+    return body ? JSON.parse(body) : null;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.name === "NoSuchKey" ||
+        error.name === "NotFound" ||
+        error.message.includes("NoSuchKey") ||
+        error.message.includes("NotFound"))
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function backfillRow({ row, client, bucket, githubPat, dryRun }) {
+  if (!row.diagram) {
+    return { status: "skipped", reason: "missing_diagram" };
+  }
+
+  const artifactTimestamp = getArtifactTimestamp(row);
+  if (!artifactTimestamp) {
+    return { status: "skipped", reason: "missing_timestamp" };
+  }
+
+  const key = artifactKey(row.username, row.repo);
+  const existing = await getExistingArtifact(client, bucket, key);
+  if (
+    existing?.lastSuccessfulAt &&
+    new Date(existing.lastSuccessfulAt).getTime() >=
+      new Date(artifactTimestamp).getTime()
+  ) {
+    return { status: "skipped", reason: "newer_object_exists" };
+  }
+
+  const mermaidValid = await validateMermaidSyntax(row.diagram);
+  if (!mermaidValid) {
+    return { status: "skipped", reason: "invalid_mermaid" };
+  }
+
+  const metadata = await fetchRepoMetadata(row.username, row.repo, githubPat);
+  if (!metadata) {
+    return { status: "skipped", reason: "repo_not_found" };
+  }
+  if (metadata.private) {
+    return { status: "skipped", reason: "private_repo" };
+  }
+
+  const payload = {
+    version: 1,
+    visibility: "public",
+    username: row.username,
+    repo: row.repo,
+    diagram: row.diagram,
+    explanation: row.explanation,
+    graph: row.graph,
+    generatedAt: artifactTimestamp,
+    usedOwnKey: Boolean(row.usedOwnKey),
+    latestSessionSummary: getStoredSessionSummary(row),
+    lastSuccessfulAt: artifactTimestamp,
+  };
+
+  if (!dryRun) {
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: JSON.stringify(payload),
+        ContentType: "application/json",
+      }),
+    );
+  }
+
+  return { status: "uploaded" };
+}
+
+const args = parseArgs(process.argv.slice(2));
+const databaseUrl = readEnv("POSTGRES_URL");
+const publicBucket = readEnv("R2_PUBLIC_BUCKET");
+
+if (!databaseUrl) {
+  throw new Error("Missing POSTGRES_URL.");
+}
+if (!readEnv("R2_ACCOUNT_ID") || !readEnv("R2_ACCESS_KEY_ID") || !readEnv("R2_SECRET_ACCESS_KEY") || !publicBucket) {
+  throw new Error("Missing R2 public bucket configuration.");
+}
+
+const githubPat = readEnv("GITHUB_PAT");
+const [cursorUsername, cursorRepo] = args.cursor?.split("/") ?? [];
+
+const sql = postgres(databaseUrl);
+const rows = await sql.unsafe(
+  `
+    select
+      username,
+      repo,
+      diagram,
+      explanation,
+      graph,
+      latest_session_status as "latestSessionStatus",
+      latest_session_stage as "latestSessionStage",
+      latest_session_provider as "latestSessionProvider",
+      latest_session_model as "latestSessionModel",
+      latest_session_audit as "latestSessionAudit",
+      last_successful_at as "lastSuccessfulAt",
+      created_at as "createdAt",
+      updated_at as "updatedAt",
+      used_own_key as "usedOwnKey"
+    from gitdiagram_diagram_cache
+    where coalesce(diagram, '') <> ''
+      and (
+        $1::text is null
+        or (username, repo) > ($1, $2)
+      )
+    order by username asc, repo asc
+    limit $3
+  `,
+  [cursorUsername ?? null, cursorRepo ?? null, args.limit],
+);
+
+const client = getS3Client();
+const summary = {
+  uploaded: 0,
+  skipped: 0,
+  errors: 0,
+  reasons: {},
+  rateLimited: false,
+  rateLimitedAt: null,
+  rateLimitedResetAt: null,
+  rateLimitedRetryAfter: null,
+};
+
+let nextCursor = rows.at(-1)
+  ? `${rows.at(-1).username}/${rows.at(-1).repo}`
+  : null;
+
+outer: for (let index = 0; index < rows.length; index += args.concurrency) {
+  const batch = rows.slice(index, index + args.concurrency);
+  nextCursor = `${batch[0].username}/${batch[0].repo}`;
+  const results = await Promise.allSettled(
+    batch.map((row) =>
+      backfillRow({
+        row,
+        client,
+        bucket: publicBucket,
+        githubPat,
+        dryRun: args.dryRun,
+      }),
+    ),
+  );
+
+  for (let resultIndex = 0; resultIndex < results.length; resultIndex += 1) {
+    const row = batch[resultIndex];
+    const result = results[resultIndex];
+
+    if (result.status === "rejected") {
+      if (result.reason instanceof GithubRateLimitError) {
+        summary.rateLimited = true;
+        summary.rateLimitedAt = `${result.reason.username}/${result.reason.repo}`;
+        summary.rateLimitedResetAt = result.reason.resetAt;
+        summary.rateLimitedRetryAfter = result.reason.retryAfter;
+        nextCursor = `${result.reason.username}/${result.reason.repo}`;
+        console.error(
+          `rate_limited ${result.reason.username}/${result.reason.repo} reset_at=${result.reason.resetAt ?? "unknown"} retry_after=${result.reason.retryAfter ?? "unknown"}`,
+        );
+        break outer;
+      }
+
+      summary.errors += 1;
+      console.error(`error ${row.username}/${row.repo}:`, result.reason);
+      continue;
+    }
+
+    if (result.value.status === "uploaded") {
+      summary.uploaded += 1;
+      console.log(`${args.dryRun ? "would_upload" : "uploaded"} ${row.username}/${row.repo}`);
+      continue;
+    }
+
+    summary.skipped += 1;
+    summary.reasons[result.value.reason] =
+      (summary.reasons[result.value.reason] ?? 0) + 1;
+  }
+}
+
+await sql.end();
+
+const processed = summary.uploaded + summary.skipped + summary.errors;
+console.log("");
+console.log(`Dry run:         ${args.dryRun ? "yes" : "no"}`);
+console.log(`Processed:       ${processed.toLocaleString()}`);
+console.log(`Uploaded:        ${summary.uploaded.toLocaleString()}`);
+console.log(`Skipped:         ${summary.skipped.toLocaleString()}`);
+console.log(`Errors:          ${summary.errors.toLocaleString()}`);
+for (const [reason, count] of Object.entries(summary.reasons)) {
+  console.log(`Skip ${reason}: ${count.toLocaleString()}`);
+}
+if (summary.rateLimited) {
+  console.log(`Rate limited:    yes`);
+  if (summary.rateLimitedResetAt) {
+    console.log(`Rate reset at:   ${summary.rateLimitedResetAt}`);
+  }
+  if (summary.rateLimitedRetryAfter !== null) {
+    console.log(`Retry after:     ${summary.rateLimitedRetryAfter}`);
+  }
+}
+if (nextCursor) {
+  console.log(`Next cursor:     ${nextCursor}`);
+}

--- a/scripts/complimentary-quota-today.mjs
+++ b/scripts/complimentary-quota-today.mjs
@@ -3,44 +3,99 @@ import postgres from "postgres";
 
 config({ path: ".env" });
 
-const databaseUrl = process.env.POSTGRES_URL?.trim();
-if (!databaseUrl) {
-  throw new Error("Missing POSTGRES_URL in .env");
+function readEnv(name) {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function quotaKey(quotaDateUtc, quotaBucket) {
+  const pricingModel = quotaBucket.split(":")[1] ?? quotaBucket;
+  return `quota:v1:${quotaDateUtc}:${pricingModel}`;
+}
+
+async function fetchUpstashResult(path, body) {
+  const url = `${readEnv("UPSTASH_REDIS_REST_URL").replace(/\/$/, "")}${path}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${readEnv("UPSTASH_REDIS_REST_TOKEN")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Upstash request failed (${response.status}): ${await response.text()}`,
+    );
+  }
+
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(`Upstash command failed: ${payload.error}`);
+  }
+
+  return payload.result;
 }
 
 const tokenLimit = Number.parseInt(
-  process.env.OPENAI_COMPLIMENTARY_DAILY_LIMIT_TOKENS?.trim() || "10000000",
+  readEnv("OPENAI_COMPLIMENTARY_DAILY_LIMIT_TOKENS") || "10000000",
   10,
 );
 const modelFamily =
-  process.env.OPENAI_COMPLIMENTARY_MODEL_FAMILY?.trim().toLowerCase() ||
+  readEnv("OPENAI_COMPLIMENTARY_MODEL_FAMILY")?.toLowerCase() ||
   "gpt-5.4-mini";
 const quotaDateUtc = new Date().toISOString().slice(0, 10);
 const quotaBucket = `openai:${modelFamily}:complimentary`;
+const quotaBackend = readEnv("QUOTA_BACKEND")?.toLowerCase() || "postgres";
 
-const sql = postgres(databaseUrl);
-const rows = await sql.unsafe(
-  `
-    select
-      quota_date_utc as "quotaDateUtc",
-      quota_bucket as "quotaBucket",
-      used_tokens as "usedTokens",
-      reserved_tokens as "reservedTokens"
-    from gitdiagram_openai_daily_quota
-    where quota_date_utc = $1
-      and quota_bucket = $2
-    limit 1
-  `,
-  [quotaDateUtc, quotaBucket],
-);
+let usedTokens = 0;
+let reservedTokens = 0;
 
-await sql.end();
+if (quotaBackend === "upstash") {
+  if (!readEnv("UPSTASH_REDIS_REST_URL") || !readEnv("UPSTASH_REDIS_REST_TOKEN")) {
+    throw new Error("Missing Upstash Redis REST configuration in .env");
+  }
 
-const row = rows[0];
-const usedTokens = row?.usedTokens ?? 0;
-const reservedTokens = row?.reservedTokens ?? 0;
+  const result = await fetchUpstashResult("", [
+    "HMGET",
+    quotaKey(quotaDateUtc, quotaBucket),
+    "used_tokens",
+    "reserved_tokens",
+  ]);
+  usedTokens = Number.parseInt(result?.[0] ?? "0", 10) || 0;
+  reservedTokens = Number.parseInt(result?.[1] ?? "0", 10) || 0;
+} else {
+  const databaseUrl = readEnv("POSTGRES_URL");
+  if (!databaseUrl) {
+    throw new Error("Missing POSTGRES_URL in .env");
+  }
+
+  const sql = postgres(databaseUrl);
+  const rows = await sql.unsafe(
+    `
+      select
+        quota_date_utc as "quotaDateUtc",
+        quota_bucket as "quotaBucket",
+        used_tokens as "usedTokens",
+        reserved_tokens as "reservedTokens"
+      from gitdiagram_openai_daily_quota
+      where quota_date_utc = $1
+        and quota_bucket = $2
+      limit 1
+    `,
+    [quotaDateUtc, quotaBucket],
+  );
+  await sql.end();
+
+  const row = rows[0];
+  usedTokens = row?.usedTokens ?? 0;
+  reservedTokens = row?.reservedTokens ?? 0;
+}
+
 const remainingTokens = Math.max(tokenLimit - usedTokens - reservedTokens, 0);
 
+console.log(`Backend:         ${quotaBackend}`);
 console.log(`UTC date:        ${quotaDateUtc}`);
 console.log(`Bucket:          ${quotaBucket}`);
 console.log(`Daily limit:     ${tokenLimit.toLocaleString()}`);

--- a/src/app/_actions/cache.ts
+++ b/src/app/_actions/cache.ts
@@ -3,9 +3,9 @@
 import { sql } from "drizzle-orm";
 
 import type { DiagramStateResponse } from "~/features/diagram/types";
-import { db } from "~/server/db";
+import { getDb, hasDb } from "~/server/db";
 import {
-  getDiagramStateRecord,
+  getCachedDiagramStateRecord,
   recordLatestSessionRenderError,
 } from "~/server/db/diagram-state";
 import { diagramCache } from "~/server/db/schema";
@@ -13,9 +13,10 @@ import { diagramCache } from "~/server/db/schema";
 export async function getDiagramState(
   username: string,
   repo: string,
+  githubPat?: string,
 ): Promise<DiagramStateResponse> {
   try {
-    return await getDiagramStateRecord(username, repo);
+    return await getCachedDiagramStateRecord(username, repo, githubPat);
   } catch (error) {
     console.error("Error fetching diagram state:", error);
     return {
@@ -30,7 +31,11 @@ export async function getDiagramState(
 
 export async function getDiagramStats() {
   try {
-    const stats = await db
+    if (!hasDb()) {
+      return null;
+    }
+
+    const stats = await getDb()
       .select({
         totalDiagrams: sql`COUNT(*)`,
         ownKeyUsers: sql`COUNT(CASE WHEN ${diagramCache.usedOwnKey} = true THEN 1 END)`,
@@ -49,9 +54,15 @@ export async function persistDiagramRenderError(
   username: string,
   repo: string,
   renderError: string,
+  githubPat?: string,
 ) {
   try {
-    await recordLatestSessionRenderError({ username, repo, renderError });
+    await recordLatestSessionRenderError({
+      username,
+      repo,
+      githubPat,
+      renderError,
+    });
   } catch (error) {
     console.error("Error recording diagram render error:", error);
   }

--- a/src/app/_actions/repo.ts
+++ b/src/app/_actions/repo.ts
@@ -2,7 +2,11 @@
 
 import { getDiagramStateRecord } from "~/server/db/diagram-state";
 
-export async function getLastGeneratedDate(username: string, repo: string) {
-  const state = await getDiagramStateRecord(username, repo);
+export async function getLastGeneratedDate(
+  username: string,
+  repo: string,
+  githubPat?: string,
+) {
+  const state = await getDiagramStateRecord(username, repo, githubPat);
   return state.lastSuccessfulAt ? new Date(state.lastSuccessfulAt) : undefined;
 }

--- a/src/app/api/generate/stream/route.ts
+++ b/src/app/api/generate/stream/route.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { GenerationTokenUsage } from "~/features/diagram/cost";
 import { diagramGraphSchema, MAX_GRAPH_ATTEMPTS } from "~/features/diagram/graph";
+import type { ArtifactVisibility } from "~/server/storage/types";
 import { saveSuccessfulDiagramState, upsertLatestSessionAudit } from "~/server/db/diagram-state";
 import {
   buildComplimentaryReservationTokens,
@@ -110,9 +111,23 @@ export async function POST(request: Request) {
         let quotaReservation: ComplimentaryQuotaReservation | null = null;
         const actualUsages: GenerationTokenUsage[] = [];
         let hasCompleteMeasuredUsage = true;
+        let storageVisibility: ArtifactVisibility = githubPat?.trim()
+          ? "private"
+          : "public";
+
+        const persistAudit = async (nextAudit = audit) => {
+          await upsertLatestSessionAudit({
+            username,
+            repo,
+            githubPat,
+            visibility: storageVisibility,
+            audit: nextAudit,
+          });
+        };
 
         try {
           const githubData = await getGithubData(username, repo, githubPat);
+          storageVisibility = githubData.isPrivate ? "private" : "public";
           const provider = getProvider();
           const providerLabel = getProviderLabel(provider);
           const model = getModel(provider);
@@ -143,7 +158,7 @@ export async function POST(request: Request) {
               createdAt: new Date().toISOString(),
             },
           );
-          await upsertLatestSessionAudit({ username, repo, audit });
+          await persistAudit();
 
           send({
             status: "started",
@@ -166,7 +181,7 @@ export async function POST(request: Request) {
                   validationError: error,
                 },
               );
-              await upsertLatestSessionAudit({ username, repo, audit });
+              await persistAudit();
               send({
                 status: "error",
                 session_id: audit.sessionId,
@@ -203,7 +218,7 @@ export async function POST(request: Request) {
                   validationError: error,
                 },
               );
-              await upsertLatestSessionAudit({ username, repo, audit });
+              await persistAudit();
               send({
                 status: "error",
                 session_id: audit.sessionId,
@@ -228,7 +243,7 @@ export async function POST(request: Request) {
               reservedTokens: quotaReservation.reservedTokens,
               quotaResetAt: quotaReservation.quotaResetAt,
             };
-            await upsertLatestSessionAudit({ username, repo, audit });
+            await persistAudit();
           }
 
           if (tokenCount > 50000 && tokenCount < 195000 && !apiKey) {
@@ -238,7 +253,7 @@ export async function POST(request: Request) {
               failureStage: "started",
               validationError: error,
             });
-            await upsertLatestSessionAudit({ username, repo, audit });
+            await persistAudit();
             send({
               status: "error",
               session_id: audit.sessionId,
@@ -260,7 +275,7 @@ export async function POST(request: Request) {
               failureStage: "started",
               validationError: error,
             });
-            await upsertLatestSessionAudit({ username, repo, audit });
+            await persistAudit();
             send({
               status: "error",
               session_id: audit.sessionId,
@@ -280,7 +295,7 @@ export async function POST(request: Request) {
             "explanation_sent",
             `Sending explanation request to ${model}...`,
           );
-          await upsertLatestSessionAudit({ username, repo, audit });
+          await persistAudit();
           send({
             status: "explanation_sent",
             session_id: audit.sessionId,
@@ -289,7 +304,7 @@ export async function POST(request: Request) {
           await sleep(80);
 
           audit = withTimelineEvent(audit, "explanation", "Analyzing repository structure...");
-          await upsertLatestSessionAudit({ username, repo, audit });
+          await persistAudit();
           send({
             status: "explanation",
             session_id: audit.sessionId,
@@ -333,7 +348,7 @@ export async function POST(request: Request) {
 
           const explanation = extractTaggedSection(explanationResponse, "explanation");
           audit = withExplanation(audit, explanation);
-          await upsertLatestSessionAudit({ username, repo, audit });
+          await persistAudit();
 
           const fileTreeLookup = buildFileTreeLookup(githubData.fileTree);
           let validGraph = null;
@@ -354,7 +369,7 @@ export async function POST(request: Request) {
                 : `Retrying graph planning (${attempt}/${MAX_GRAPH_ATTEMPTS})...`;
 
             audit = withTimelineEvent(audit, status, message);
-            await upsertLatestSessionAudit({ username, repo, audit });
+            await persistAudit();
             send({
               status,
               session_id: audit.sessionId,
@@ -429,7 +444,7 @@ export async function POST(request: Request) {
                 "graph_validating",
                 `Graph validation failed on attempt ${attempt}/${MAX_GRAPH_ATTEMPTS}.`,
               );
-              await upsertLatestSessionAudit({ username, repo, audit });
+              await persistAudit();
               send({
                 status: "graph_validating",
                 session_id: audit.sessionId,
@@ -453,7 +468,7 @@ export async function POST(request: Request) {
               failureStage: "graph_validating",
               validationError: latestValidationError,
             });
-            await upsertLatestSessionAudit({ username, repo, audit });
+            await persistAudit();
             send({
               status: "error",
               session_id: audit.sessionId,
@@ -470,7 +485,7 @@ export async function POST(request: Request) {
           }
 
           audit = withTimelineEvent(audit, "diagram_compiling", "Compiling Mermaid diagram...");
-          await upsertLatestSessionAudit({ username, repo, audit });
+          await persistAudit();
           send({
             status: "diagram_compiling",
             session_id: audit.sessionId,
@@ -486,7 +501,7 @@ export async function POST(request: Request) {
             branch: githubData.defaultBranch,
           });
           audit = withCompiledDiagram(audit, diagram);
-          await upsertLatestSessionAudit({ username, repo, audit });
+          await persistAudit();
           send({
             status: "diagram_compiling",
             session_id: audit.sessionId,
@@ -504,7 +519,7 @@ export async function POST(request: Request) {
               failureStage: "diagram_compiling",
               compilerError,
             });
-            await upsertLatestSessionAudit({ username, repo, audit });
+            await persistAudit();
             send({
               status: "error",
               session_id: audit.sessionId,
@@ -537,6 +552,8 @@ export async function POST(request: Request) {
           await saveSuccessfulDiagramState({
             username,
             repo,
+            githubPat,
+            visibility: storageVisibility,
             explanation,
             graph: validGraph,
             diagram,
@@ -564,7 +581,7 @@ export async function POST(request: Request) {
             validationError: message,
           });
           try {
-            await upsertLatestSessionAudit({ username, repo, audit: failedAudit });
+            await persistAudit(failedAudit);
           } catch {
             // Best effort persistence.
           }
@@ -600,7 +617,7 @@ export async function POST(request: Request) {
                 reservation: quotaReservation,
                 committedTokens: actualCommittedTokens,
               });
-              await upsertLatestSessionAudit({ username, repo, audit });
+              await persistAudit();
             } catch {
               // Best effort quota finalization and audit persistence.
             }

--- a/src/env.js
+++ b/src/env.js
@@ -7,7 +7,7 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    POSTGRES_URL: z.string().url(),
+    POSTGRES_URL: z.string().url().optional(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),

--- a/src/hooks/useDiagram.test.ts
+++ b/src/hooks/useDiagram.test.ts
@@ -126,6 +126,7 @@ describe("useDiagram", () => {
         "acme",
         "demo",
         "Parse error on line 3",
+        undefined,
       ),
     );
     await waitFor(() =>

--- a/src/hooks/useDiagram.ts
+++ b/src/hooks/useDiagram.ts
@@ -75,8 +75,12 @@ export function useDiagram(username: string, repo: string) {
     setError("");
 
     try {
-      const stateRecord = await getDiagramState(username, repo);
       const githubPat = localStorage.getItem("github_pat");
+      const stateRecord = await getDiagramState(
+        username,
+        repo,
+        githubPat ?? undefined,
+      );
 
       if (stateRecord.diagram) {
         setDiagram(stateRecord.diagram);
@@ -166,7 +170,13 @@ export function useDiagram(username: string, repo: string) {
 
   const handleDiagramRenderError = useCallback(
     async (renderMessage: string) => {
-      await persistDiagramRenderError(username, repo, renderMessage);
+      const githubPat = localStorage.getItem("github_pat");
+      await persistDiagramRenderError(
+        username,
+        repo,
+        renderMessage,
+        githubPat ?? undefined,
+      );
       setError(`Diagram render failed: ${renderMessage}`);
       setState((prev) => ({
         ...prev,

--- a/src/server/db/diagram-state.ts
+++ b/src/server/db/diagram-state.ts
@@ -1,11 +1,26 @@
 import { and, eq } from "drizzle-orm";
+import { revalidateTag, unstable_cache } from "next/cache";
 
 import type {
   DiagramGraph,
   GenerationSessionAudit,
 } from "~/features/diagram/graph";
-import { db } from "~/server/db";
+import { getDb, hasDb } from "~/server/db";
 import { diagramCache } from "~/server/db/schema";
+import {
+  getStoredDiagramArtifact,
+  getStoredDiagramState,
+  toStoredSessionSummary,
+  updateArtifactLatestSessionSummary,
+  writeDiagramArtifact,
+} from "~/server/storage/artifact-store";
+import {
+  getDiagramCacheBackend,
+  hasPostgresConfig,
+  isPostgresFallbackEnabled,
+} from "~/server/storage/config";
+import { clearFailureSummary, getStoredFailureState, writeFailureSummary } from "~/server/storage/status-store";
+import type { ArtifactVisibility } from "~/server/storage/types";
 
 export interface DiagramStateRecord {
   diagram: string | null;
@@ -15,15 +30,63 @@ export interface DiagramStateRecord {
   lastSuccessfulAt: string | null;
 }
 
+function getDiagramStateTag(username: string, repo: string) {
+  return `diagram-state:${username}:${repo}`;
+}
+
+function shouldUsePostgresForReads() {
+  const backend = getDiagramCacheBackend();
+  if (backend === "postgres") {
+    return true;
+  }
+  return hasPostgresConfig() && isPostgresFallbackEnabled();
+}
+
+function shouldDualWriteToPostgres() {
+  return getDiagramCacheBackend() === "dual" && hasPostgresConfig();
+}
+
+function shouldUseObjectStorage() {
+  const backend = getDiagramCacheBackend();
+  return backend === "dual" || backend === "object";
+}
+
+function inferVisibility(params: {
+  visibility?: ArtifactVisibility;
+  githubPat?: string;
+}): ArtifactVisibility {
+  return params.visibility ?? (params.githubPat?.trim() ? "private" : "public");
+}
+
+function revalidateDiagramState(params: {
+  username: string;
+  repo: string;
+  visibility: ArtifactVisibility;
+}) {
+  if (params.visibility === "public") {
+    revalidateTag(getDiagramStateTag(params.username, params.repo), "max");
+  }
+}
+
 function toIsoString(value: Date | null | undefined): string | null {
   return value ? value.toISOString() : null;
 }
 
-export async function getDiagramStateRecord(
+async function getDiagramStateRecordFromPostgres(
   username: string,
   repo: string,
 ): Promise<DiagramStateRecord> {
-  const result = await db
+  if (!hasDb()) {
+    return {
+      diagram: null,
+      explanation: null,
+      graph: null,
+      latestSessionAudit: null,
+      lastSuccessfulAt: null,
+    };
+  }
+
+  const result = await getDb()
     .select()
     .from(diagramCache)
     .where(and(eq(diagramCache.username, username), eq(diagramCache.repo, repo)))
@@ -39,12 +102,16 @@ export async function getDiagramStateRecord(
   };
 }
 
-export async function upsertLatestSessionAudit(params: {
+async function upsertLatestSessionAuditInPostgres(params: {
   username: string;
   repo: string;
   audit: GenerationSessionAudit;
 }) {
-  await db
+  if (!hasDb()) {
+    return;
+  }
+
+  await getDb()
     .insert(diagramCache)
     .values({
       username: params.username,
@@ -70,7 +137,7 @@ export async function upsertLatestSessionAudit(params: {
     });
 }
 
-export async function saveSuccessfulDiagramState(params: {
+async function saveSuccessfulDiagramStateInPostgres(params: {
   username: string;
   repo: string;
   explanation: string;
@@ -79,9 +146,12 @@ export async function saveSuccessfulDiagramState(params: {
   audit: GenerationSessionAudit;
   usedOwnKey: boolean;
 }) {
-  const successfulAt = new Date();
+  if (!hasDb()) {
+    return;
+  }
 
-  await db
+  const successfulAt = new Date();
+  await getDb()
     .insert(diagramCache)
     .values({
       username: params.username,
@@ -117,16 +187,186 @@ export async function saveSuccessfulDiagramState(params: {
     });
 }
 
+export async function getDiagramStateRecord(
+  username: string,
+  repo: string,
+  githubPat?: string,
+): Promise<DiagramStateRecord> {
+  if (shouldUseObjectStorage()) {
+    const storedArtifactState = await getStoredDiagramState({
+      username,
+      repo,
+      githubPat,
+    });
+    if (storedArtifactState) {
+      return storedArtifactState;
+    }
+
+    const storedFailureState = await getStoredFailureState({
+      username,
+      repo,
+      githubPat,
+    });
+    if (storedFailureState) {
+      return storedFailureState;
+    }
+  }
+
+  if (shouldUsePostgresForReads()) {
+    return getDiagramStateRecordFromPostgres(username, repo);
+  }
+
+  return {
+    diagram: null,
+    explanation: null,
+    graph: null,
+    latestSessionAudit: null,
+    lastSuccessfulAt: null,
+  };
+}
+
+export async function getCachedDiagramStateRecord(
+  username: string,
+  repo: string,
+  githubPat?: string,
+): Promise<DiagramStateRecord> {
+  if (githubPat?.trim()) {
+    return getDiagramStateRecord(username, repo, githubPat);
+  }
+
+  return unstable_cache(
+    async () => getDiagramStateRecord(username, repo),
+    ["diagram-state", username, repo],
+    {
+      tags: [getDiagramStateTag(username, repo)],
+      revalidate: 60 * 60,
+    },
+  )();
+}
+
+export async function upsertLatestSessionAudit(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+  visibility?: ArtifactVisibility;
+  audit: GenerationSessionAudit;
+}) {
+  const visibility = inferVisibility(params);
+
+  if (getDiagramCacheBackend() === "postgres") {
+    await upsertLatestSessionAuditInPostgres(params);
+    revalidateDiagramState({ username: params.username, repo: params.repo, visibility });
+    return;
+  }
+
+  const slimAudit = toStoredSessionSummary(params.audit);
+
+  if (params.audit.status === "failed") {
+    const artifactUpdated = await updateArtifactLatestSessionSummary({
+      username: params.username,
+      repo: params.repo,
+      githubPat: params.githubPat,
+      visibility,
+      latestSessionSummary: slimAudit,
+    });
+
+    if (!artifactUpdated) {
+      await writeFailureSummary({
+        username: params.username,
+        repo: params.repo,
+        githubPat: params.githubPat,
+        visibility,
+        latestSessionSummary: slimAudit,
+      });
+    } else {
+      await clearFailureSummary({
+        username: params.username,
+        repo: params.repo,
+        githubPat: params.githubPat,
+        visibility,
+      });
+    }
+  }
+
+  if (shouldDualWriteToPostgres() && params.audit.status !== "running") {
+    await upsertLatestSessionAuditInPostgres(params);
+  }
+
+  if (params.audit.status === "failed") {
+    revalidateDiagramState({ username: params.username, repo: params.repo, visibility });
+  }
+}
+
+export async function saveSuccessfulDiagramState(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+  visibility: ArtifactVisibility;
+  explanation: string;
+  graph: DiagramGraph;
+  diagram: string;
+  audit: GenerationSessionAudit;
+  usedOwnKey: boolean;
+}) {
+  const successfulAt = params.audit.updatedAt || new Date().toISOString();
+
+  if (shouldUseObjectStorage()) {
+    await writeDiagramArtifact({
+      username: params.username,
+      repo: params.repo,
+      githubPat: params.githubPat,
+      visibility: params.visibility,
+      diagram: params.diagram,
+      explanation: params.explanation,
+      graph: params.graph,
+      generatedAt: successfulAt,
+      usedOwnKey: params.usedOwnKey,
+      latestSessionSummary: toStoredSessionSummary(params.audit),
+      lastSuccessfulAt: successfulAt,
+    });
+    await clearFailureSummary({
+      username: params.username,
+      repo: params.repo,
+      githubPat: params.githubPat,
+      visibility: params.visibility,
+    });
+  }
+
+  if (getDiagramCacheBackend() === "postgres" || shouldDualWriteToPostgres()) {
+    await saveSuccessfulDiagramStateInPostgres(params);
+  }
+
+  revalidateDiagramState({
+    username: params.username,
+    repo: params.repo,
+    visibility: params.visibility,
+  });
+}
+
 export async function recordLatestSessionRenderError(params: {
   username: string;
   repo: string;
+  githubPat?: string;
   renderError: string;
 }) {
-  const current = await getDiagramStateRecord(params.username, params.repo);
+  const current = await getDiagramStateRecord(
+    params.username,
+    params.repo,
+    params.githubPat,
+  );
   const audit = current.latestSessionAudit;
   if (!audit) {
     return;
   }
+
+  const visibility =
+    (
+      await getStoredDiagramArtifact({
+        username: params.username,
+        repo: params.repo,
+        githubPat: params.githubPat,
+      })
+    )?.location.visibility ?? inferVisibility(params);
 
   const nextAudit: GenerationSessionAudit = {
     ...audit,
@@ -148,6 +388,8 @@ export async function recordLatestSessionRenderError(params: {
   await upsertLatestSessionAudit({
     username: params.username,
     repo: params.repo,
+    githubPat: params.githubPat,
+    visibility,
     audit: nextAudit,
   });
 }

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -14,18 +14,30 @@ type DrizzleDatabase =
   | NeonHttpDatabase<typeof schema>
   | PostgresJsDatabase<typeof schema>;
 
-// Check if we're using Neon/Vercel (production) or local Postgres
-const isNeonConnection = process.env.POSTGRES_URL?.includes("neon.tech");
+let db: DrizzleDatabase | null = null;
 
-let db: DrizzleDatabase;
-if (isNeonConnection) {
-  // Production: Use Neon HTTP connection
-  const sql = neon(process.env.POSTGRES_URL!);
-  db = drizzleNeon(sql, { schema });
-} else {
-  // Local development: Use standard Postgres connection
-  const client = postgres(process.env.POSTGRES_URL!);
-  db = drizzlePostgres(client, { schema });
+export function hasDb() {
+  return Boolean(process.env.POSTGRES_URL?.trim());
 }
 
-export { db };
+export function getDb(): DrizzleDatabase {
+  if (db) {
+    return db;
+  }
+
+  const databaseUrl = process.env.POSTGRES_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error("Missing POSTGRES_URL for database access.");
+  }
+
+  const isNeonConnection = databaseUrl.includes("neon.tech");
+  if (isNeonConnection) {
+    const sql = neon(databaseUrl);
+    db = drizzleNeon(sql, { schema });
+    return db;
+  }
+
+  const client = postgres(databaseUrl);
+  db = drizzlePostgres(client, { schema });
+  return db;
+}

--- a/src/server/generate/complimentary-gate.test.ts
+++ b/src/server/generate/complimentary-gate.test.ts
@@ -3,14 +3,29 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const {
   reserveComplimentaryQuotaInDb,
   finalizeComplimentaryQuotaInDb,
+  reserveQuotaInUpstash,
+  finalizeQuotaInUpstash,
+  getQuotaBackend,
 } = vi.hoisted(() => ({
   reserveComplimentaryQuotaInDb: vi.fn(),
   finalizeComplimentaryQuotaInDb: vi.fn(),
+  reserveQuotaInUpstash: vi.fn(),
+  finalizeQuotaInUpstash: vi.fn(),
+  getQuotaBackend: vi.fn(() => "postgres"),
 }));
 
 vi.mock("~/server/db/complimentary-quota", () => ({
   reserveComplimentaryQuota: reserveComplimentaryQuotaInDb,
   finalizeComplimentaryQuota: finalizeComplimentaryQuotaInDb,
+}));
+
+vi.mock("~/server/storage/quota-store", () => ({
+  reserveQuotaInUpstash,
+  finalizeQuotaInUpstash,
+}));
+
+vi.mock("~/server/storage/config", () => ({
+  getQuotaBackend,
 }));
 
 import {
@@ -26,6 +41,7 @@ describe("complimentary gate", () => {
     delete process.env.OPENAI_COMPLIMENTARY_GATE_ENABLED;
     delete process.env.OPENAI_COMPLIMENTARY_DAILY_LIMIT_TOKENS;
     delete process.env.OPENAI_COMPLIMENTARY_MODEL_FAMILY;
+    getQuotaBackend.mockReturnValue("postgres");
     vi.clearAllMocks();
   });
 
@@ -114,5 +130,49 @@ describe("complimentary gate", () => {
       reservationTokens: 50_700,
       committedTokens: 345,
     });
+  });
+
+  it("routes quota operations through Upstash when configured", async () => {
+    getQuotaBackend.mockReturnValue("upstash");
+    reserveQuotaInUpstash.mockResolvedValue({
+      admitted: true,
+      usage: { usedTokens: 1_000, reservedTokens: 2_000 },
+    });
+    finalizeQuotaInUpstash.mockResolvedValue({
+      usedTokens: 1_345,
+      reservedTokens: 1_655,
+    });
+
+    const reservation = await reserveComplimentaryQuota({
+      model: "gpt-5.4-mini",
+      reservationTokens: 1_000,
+      now: new Date("2026-03-28T12:34:56.000Z"),
+    });
+
+    expect(reserveQuotaInUpstash).toHaveBeenCalledWith({
+      quotaDateUtc: "2026-03-28",
+      quotaBucket: "openai:gpt-5.4-mini:complimentary",
+      reservationTokens: 1_000,
+      tokenLimit: 10_000_000,
+    });
+    expect(reserveComplimentaryQuotaInDb).not.toHaveBeenCalled();
+    expect(reservation.admitted).toBe(true);
+
+    if (!reservation.admitted) {
+      throw new Error("expected admitted reservation");
+    }
+
+    await finalizeComplimentaryQuota({
+      reservation: reservation.reservation,
+      committedTokens: 345,
+    });
+
+    expect(finalizeQuotaInUpstash).toHaveBeenCalledWith({
+      quotaDateUtc: "2026-03-28",
+      quotaBucket: "openai:gpt-5.4-mini:complimentary",
+      reservationTokens: 1_000,
+      committedTokens: 345,
+    });
+    expect(finalizeComplimentaryQuotaInDb).not.toHaveBeenCalled();
   });
 });

--- a/src/server/generate/complimentary-gate.ts
+++ b/src/server/generate/complimentary-gate.ts
@@ -3,6 +3,11 @@ import {
   finalizeComplimentaryQuota as finalizeComplimentaryQuotaInDb,
   reserveComplimentaryQuota as reserveComplimentaryQuotaInDb,
 } from "~/server/db/complimentary-quota";
+import {
+  finalizeQuotaInUpstash,
+  reserveQuotaInUpstash,
+} from "~/server/storage/quota-store";
+import { getQuotaBackend } from "~/server/storage/config";
 import type { AIProvider } from "~/server/generate/model-config";
 import {
   EXPLANATION_MAX_OUTPUT_TOKENS,
@@ -146,7 +151,10 @@ export async function reserveComplimentaryQuota(params: {
   const quotaDateUtc = getComplimentaryQuotaDateUtc(now);
   const quotaResetAt = getComplimentaryQuotaResetAt(now);
   const quotaBucket = getComplimentaryQuotaBucket(params.model);
-  const result = await reserveComplimentaryQuotaInDb({
+  const reserve = getQuotaBackend() === "upstash"
+    ? reserveQuotaInUpstash
+    : reserveComplimentaryQuotaInDb;
+  const result = await reserve({
     quotaDateUtc,
     quotaBucket,
     tokenLimit: getComplimentaryDailyLimitTokens(),
@@ -176,7 +184,10 @@ export async function finalizeComplimentaryQuota(params: {
   reservation: ComplimentaryQuotaReservation;
   committedTokens: number;
 }): Promise<void> {
-  await finalizeComplimentaryQuotaInDb({
+  const finalize = getQuotaBackend() === "upstash"
+    ? finalizeQuotaInUpstash
+    : finalizeComplimentaryQuotaInDb;
+  await finalize({
     quotaDateUtc: params.reservation.quotaDateUtc,
     quotaBucket: params.reservation.quotaBucket,
     reservationTokens: params.reservation.reservedTokens,

--- a/src/server/generate/github.ts
+++ b/src/server/generate/github.ts
@@ -1,5 +1,6 @@
 interface GitHubRepoResponse {
   default_branch?: string;
+  private?: boolean;
 }
 
 interface GitHubTreeItem {
@@ -19,6 +20,7 @@ export interface GithubData {
   defaultBranch: string;
   fileTree: string;
   readme: string;
+  isPrivate: boolean;
 }
 
 const EXCLUDED_PATTERNS = [
@@ -94,18 +96,21 @@ async function fetchJson<T>(
   return (await response.json()) as T;
 }
 
-async function getDefaultBranch(
+async function getRepoMetadata(
   username: string,
   repo: string,
   headers: HeadersInit,
-): Promise<string> {
+): Promise<{ defaultBranch: string; isPrivate: boolean }> {
   const data = await fetchJson<GitHubRepoResponse>(
     `https://api.github.com/repos/${username}/${repo}`,
     headers,
     "Repository not found.",
   );
 
-  return data.default_branch || "main";
+  return {
+    defaultBranch: data.default_branch || "main",
+    isPrivate: Boolean(data.private),
+  };
 }
 
 async function getFileTree(
@@ -162,7 +167,11 @@ export async function getGithubData(
   githubPat?: string,
 ): Promise<GithubData> {
   const headers = createHeaders(githubPat);
-  const defaultBranch = await getDefaultBranch(username, repo, headers);
+  const { defaultBranch, isPrivate } = await getRepoMetadata(
+    username,
+    repo,
+    headers,
+  );
   const [fileTree, readme] = await Promise.all([
     getFileTree(username, repo, defaultBranch, headers),
     getReadme(username, repo, headers),
@@ -172,5 +181,6 @@ export async function getGithubData(
     defaultBranch,
     fileTree,
     readme,
+    isPrivate,
   };
 }

--- a/src/server/storage/artifact-store.ts
+++ b/src/server/storage/artifact-store.ts
@@ -1,0 +1,151 @@
+import type { DiagramStateResponse } from "~/features/diagram/types";
+import type { GenerationSessionAudit } from "~/features/diagram/graph";
+import {
+  getPrivateLocation,
+  getReadLocations,
+  getPublicLocation,
+  type StorageLocation,
+} from "~/server/storage/cache-key";
+import { getJsonObject, putJsonObject } from "~/server/storage/r2";
+import type {
+  ArtifactVisibility,
+  DiagramArtifact,
+} from "~/server/storage/types";
+
+export function toStoredSessionSummary(
+  audit: GenerationSessionAudit,
+): GenerationSessionAudit {
+  return {
+    sessionId: audit.sessionId,
+    status: audit.status,
+    stage: audit.stage,
+    provider: audit.provider,
+    model: audit.model,
+    quotaStatus: audit.quotaStatus,
+    quotaBucket: audit.quotaBucket,
+    quotaDateUtc: audit.quotaDateUtc,
+    reservedTokens: audit.reservedTokens,
+    actualCommittedTokens: audit.actualCommittedTokens,
+    quotaResetAt: audit.quotaResetAt,
+    estimatedCost: audit.estimatedCost,
+    finalCost: audit.finalCost,
+    graph: audit.graph,
+    graphAttempts: audit.status === "failed" ? audit.graphAttempts : [],
+    stageUsages: [],
+    validationError: audit.validationError,
+    failureStage: audit.failureStage,
+    compilerError: audit.compilerError,
+    renderError: audit.renderError,
+    timeline: [],
+    createdAt: audit.createdAt,
+    updatedAt: audit.updatedAt,
+  };
+}
+
+function toDiagramStateResponse(
+  artifact: DiagramArtifact,
+): DiagramStateResponse {
+  return {
+    diagram: artifact.diagram,
+    explanation: artifact.explanation,
+    graph: artifact.graph,
+    latestSessionAudit: artifact.latestSessionSummary,
+    lastSuccessfulAt: artifact.lastSuccessfulAt,
+  };
+}
+
+async function getArtifactForLocation(
+  location: StorageLocation,
+): Promise<DiagramArtifact | null> {
+  return getJsonObject<DiagramArtifact>(location.bucket, location.artifactKey);
+}
+
+export async function getStoredDiagramArtifact(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+}): Promise<{
+  artifact: DiagramArtifact;
+  location: StorageLocation;
+} | null> {
+  for (const location of getReadLocations(params)) {
+    const artifact = await getArtifactForLocation(location);
+    if (artifact) {
+      return { artifact, location };
+    }
+  }
+
+  return null;
+}
+
+export async function getStoredDiagramState(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+}): Promise<DiagramStateResponse | null> {
+  const result = await getStoredDiagramArtifact(params);
+  if (!result) {
+    return null;
+  }
+
+  return toDiagramStateResponse(result.artifact);
+}
+
+export async function writeDiagramArtifact(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+  visibility: ArtifactVisibility;
+  diagram: string;
+  explanation: string;
+  graph: GenerationSessionAudit["graph"];
+  generatedAt: string;
+  usedOwnKey: boolean;
+  latestSessionSummary: GenerationSessionAudit;
+  lastSuccessfulAt: string;
+}): Promise<void> {
+  const location =
+    params.visibility === "private"
+      ? getPrivateLocation(params.username, params.repo, params.githubPat ?? "")
+      : getPublicLocation(params.username, params.repo);
+
+  const artifact: DiagramArtifact = {
+    version: 1,
+    visibility: params.visibility,
+    username: params.username,
+    repo: params.repo,
+    diagram: params.diagram,
+    explanation: params.explanation,
+    graph: params.graph,
+    generatedAt: params.generatedAt,
+    usedOwnKey: params.usedOwnKey,
+    latestSessionSummary: params.latestSessionSummary,
+    lastSuccessfulAt: params.lastSuccessfulAt,
+  };
+
+  await putJsonObject(location.bucket, location.artifactKey, artifact);
+}
+
+export async function updateArtifactLatestSessionSummary(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+  visibility: ArtifactVisibility;
+  latestSessionSummary: GenerationSessionAudit;
+}): Promise<boolean> {
+  const location =
+    params.visibility === "private"
+      ? getPrivateLocation(params.username, params.repo, params.githubPat ?? "")
+      : getPublicLocation(params.username, params.repo);
+
+  const artifact = await getArtifactForLocation(location);
+  if (!artifact) {
+    return false;
+  }
+
+  await putJsonObject(location.bucket, location.artifactKey, {
+    ...artifact,
+    latestSessionSummary: params.latestSessionSummary,
+  } satisfies DiagramArtifact);
+  return true;
+}

--- a/src/server/storage/cache-key.ts
+++ b/src/server/storage/cache-key.ts
@@ -1,0 +1,64 @@
+import { createHmac } from "node:crypto";
+
+import type { ArtifactVisibility } from "~/server/storage/types";
+import { readRequiredEnv } from "~/server/storage/config";
+
+function normalizeSegment(value: string): string {
+  return encodeURIComponent(value.trim().toLowerCase());
+}
+
+function createPatNamespace(githubPat: string): string {
+  const secret = readRequiredEnv("CACHE_KEY_SECRET");
+  return createHmac("sha256", secret).update(githubPat.trim()).digest("hex");
+}
+
+export interface StorageLocation {
+  visibility: ArtifactVisibility;
+  bucket: string;
+  artifactKey: string;
+  statusKey: string;
+}
+
+export function getPublicLocation(username: string, repo: string): StorageLocation {
+  const normalizedUsername = normalizeSegment(username);
+  const normalizedRepo = normalizeSegment(repo);
+
+  return {
+    visibility: "public",
+    bucket: readRequiredEnv("R2_PUBLIC_BUCKET"),
+    artifactKey: `public/v1/${normalizedUsername}/${normalizedRepo}.json`,
+    statusKey: `status:v1:public:${normalizedUsername}:${normalizedRepo}`,
+  };
+}
+
+export function getPrivateLocation(
+  username: string,
+  repo: string,
+  githubPat: string,
+): StorageLocation {
+  const normalizedUsername = normalizeSegment(username);
+  const normalizedRepo = normalizeSegment(repo);
+  const namespace = createPatNamespace(githubPat);
+
+  return {
+    visibility: "private",
+    bucket: readRequiredEnv("R2_PRIVATE_BUCKET"),
+    artifactKey: `private/v1/${namespace}/${normalizedUsername}/${normalizedRepo}.json`,
+    statusKey: `status:v1:private:${namespace}:${normalizedUsername}:${normalizedRepo}`,
+  };
+}
+
+export function getReadLocations(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+}): StorageLocation[] {
+  const locations: StorageLocation[] = [];
+  if (params.githubPat?.trim()) {
+    locations.push(
+      getPrivateLocation(params.username, params.repo, params.githubPat),
+    );
+  }
+  locations.push(getPublicLocation(params.username, params.repo));
+  return locations;
+}

--- a/src/server/storage/config.ts
+++ b/src/server/storage/config.ts
@@ -1,0 +1,59 @@
+export type DiagramCacheBackend = "postgres" | "dual" | "object";
+export type QuotaBackend = "postgres" | "upstash";
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+export function readRequiredEnv(name: string): string {
+  const value = readEnv(name);
+  if (!value) {
+    throw new Error(`Missing ${name}.`);
+  }
+  return value;
+}
+
+export function getDiagramCacheBackend(): DiagramCacheBackend {
+  const value = readEnv("DIAGRAM_CACHE_BACKEND")?.toLowerCase();
+  if (value === "postgres" || value === "dual" || value === "object") {
+    return value;
+  }
+  return hasR2Config() ? "object" : "postgres";
+}
+
+export function getQuotaBackend(): QuotaBackend {
+  const value = readEnv("QUOTA_BACKEND")?.toLowerCase();
+  if (value === "postgres" || value === "upstash") {
+    return value;
+  }
+  return hasUpstashConfig() ? "upstash" : "postgres";
+}
+
+export function isPostgresFallbackEnabled(): boolean {
+  const value = readEnv("POSTGRES_FALLBACK_ENABLED")?.toLowerCase();
+  if (!value) {
+    return false;
+  }
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+export function hasPostgresConfig(): boolean {
+  return Boolean(readEnv("POSTGRES_URL"));
+}
+
+export function hasR2Config(): boolean {
+  return Boolean(
+    readEnv("R2_ACCOUNT_ID") &&
+      readEnv("R2_ACCESS_KEY_ID") &&
+      readEnv("R2_SECRET_ACCESS_KEY") &&
+      readEnv("R2_PUBLIC_BUCKET") &&
+      readEnv("R2_PRIVATE_BUCKET"),
+  );
+}
+
+export function hasUpstashConfig(): boolean {
+  return Boolean(
+    readEnv("UPSTASH_REDIS_REST_URL") && readEnv("UPSTASH_REDIS_REST_TOKEN"),
+  );
+}

--- a/src/server/storage/quota-store.ts
+++ b/src/server/storage/quota-store.ts
@@ -1,0 +1,97 @@
+import { upstashEval } from "~/server/storage/upstash";
+
+const QUOTA_TTL_SECONDS = 3 * 24 * 60 * 60;
+
+const RESERVE_SCRIPT = `
+local key = KEYS[1]
+local token_limit = tonumber(ARGV[1])
+local reservation_tokens = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+
+local used_tokens = tonumber(redis.call("HGET", key, "used_tokens") or "0")
+local reserved_tokens = tonumber(redis.call("HGET", key, "reserved_tokens") or "0")
+
+if used_tokens + reserved_tokens + reservation_tokens > token_limit then
+  return {0, used_tokens, reserved_tokens}
+end
+
+local next_reserved_tokens = reserved_tokens + reservation_tokens
+redis.call("HSET", key, "used_tokens", used_tokens, "reserved_tokens", next_reserved_tokens)
+redis.call("EXPIRE", key, ttl)
+
+return {1, used_tokens, next_reserved_tokens}
+`;
+
+const FINALIZE_SCRIPT = `
+local key = KEYS[1]
+local reservation_tokens = tonumber(ARGV[1])
+local committed_tokens = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+
+local used_tokens = tonumber(redis.call("HGET", key, "used_tokens") or "0")
+local reserved_tokens = tonumber(redis.call("HGET", key, "reserved_tokens") or "0")
+
+local next_reserved_tokens = reserved_tokens - reservation_tokens
+if next_reserved_tokens < 0 then
+  next_reserved_tokens = 0
+end
+
+local next_used_tokens = used_tokens + math.max(committed_tokens, 0)
+redis.call("HSET", key, "used_tokens", next_used_tokens, "reserved_tokens", next_reserved_tokens)
+redis.call("EXPIRE", key, ttl)
+
+return {next_used_tokens, next_reserved_tokens}
+`;
+
+function quotaKey(quotaDateUtc: string, quotaBucket: string): string {
+  const pricingModel = quotaBucket.split(":")[1] ?? quotaBucket;
+  return `quota:v1:${quotaDateUtc}:${pricingModel}`;
+}
+
+export interface DailyQuotaUsage {
+  usedTokens: number;
+  reservedTokens: number;
+}
+
+export async function reserveQuotaInUpstash(params: {
+  quotaDateUtc: string;
+  quotaBucket: string;
+  tokenLimit: number;
+  reservationTokens: number;
+}): Promise<{ admitted: boolean; usage: DailyQuotaUsage }> {
+  const result = await upstashEval<[number, number, number]>({
+    script: RESERVE_SCRIPT,
+    keys: [quotaKey(params.quotaDateUtc, params.quotaBucket)],
+    args: [params.tokenLimit, params.reservationTokens, QUOTA_TTL_SECONDS],
+  });
+
+  return {
+    admitted: result[0] === 1,
+    usage: {
+      usedTokens: result[1] ?? 0,
+      reservedTokens: result[2] ?? 0,
+    },
+  };
+}
+
+export async function finalizeQuotaInUpstash(params: {
+  quotaDateUtc: string;
+  quotaBucket: string;
+  reservationTokens: number;
+  committedTokens: number;
+}): Promise<DailyQuotaUsage> {
+  const result = await upstashEval<[number, number]>({
+    script: FINALIZE_SCRIPT,
+    keys: [quotaKey(params.quotaDateUtc, params.quotaBucket)],
+    args: [
+      params.reservationTokens,
+      params.committedTokens,
+      QUOTA_TTL_SECONDS,
+    ],
+  });
+
+  return {
+    usedTokens: result[0] ?? 0,
+    reservedTokens: result[1] ?? 0,
+  };
+}

--- a/src/server/storage/r2.ts
+++ b/src/server/storage/r2.ts
@@ -1,0 +1,111 @@
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+
+import { readRequiredEnv } from "~/server/storage/config";
+
+let client: S3Client | null = null;
+
+function getClient(): S3Client {
+  if (client) {
+    return client;
+  }
+
+  client = new S3Client({
+    region: "auto",
+    endpoint: `https://${readRequiredEnv("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: readRequiredEnv("R2_ACCESS_KEY_ID"),
+      secretAccessKey: readRequiredEnv("R2_SECRET_ACCESS_KEY"),
+    },
+  });
+
+  return client;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.name === "NoSuchKey" ||
+    error.name === "NotFound" ||
+    error.message.includes("NotFound") ||
+    error.message.includes("NoSuchKey")
+  );
+}
+
+export async function getJsonObject<T>(
+  bucket: string,
+  key: string,
+): Promise<T | null> {
+  try {
+    const response = await getClient().send(
+      new GetObjectCommand({
+        Bucket: bucket,
+        Key: key,
+      }),
+    );
+
+    const body = await response.Body?.transformToString();
+    if (!body) {
+      return null;
+    }
+
+    return JSON.parse(body) as T;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function putJsonObject(
+  bucket: string,
+  key: string,
+  payload: unknown,
+): Promise<void> {
+  await getClient().send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: JSON.stringify(payload),
+      ContentType: "application/json",
+    }),
+  );
+}
+
+export async function deleteObject(bucket: string, key: string): Promise<void> {
+  await getClient().send(
+    new DeleteObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    }),
+  );
+}
+
+export async function objectExists(
+  bucket: string,
+  key: string,
+): Promise<boolean> {
+  try {
+    await getClient().send(
+      new HeadObjectCommand({
+        Bucket: bucket,
+        Key: key,
+      }),
+    );
+    return true;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/src/server/storage/status-store.ts
+++ b/src/server/storage/status-store.ts
@@ -1,0 +1,96 @@
+import type { DiagramStateResponse } from "~/features/diagram/types";
+import type { GenerationSessionAudit } from "~/features/diagram/graph";
+import {
+  getPrivateLocation,
+  getReadLocations,
+  getPublicLocation,
+  type StorageLocation,
+} from "~/server/storage/cache-key";
+import { upstashCommand } from "~/server/storage/upstash";
+import type {
+  ArtifactVisibility,
+  StoredFailureSummary,
+} from "~/server/storage/types";
+
+const STATUS_TTL_SECONDS = 3 * 24 * 60 * 60;
+
+function toDiagramStateResponse(
+  summary: StoredFailureSummary,
+): DiagramStateResponse {
+  return {
+    diagram: null,
+    explanation: null,
+    graph: null,
+    latestSessionAudit: summary.latestSessionSummary,
+    lastSuccessfulAt: null,
+  };
+}
+
+async function getSummaryForLocation(
+  location: StorageLocation,
+): Promise<StoredFailureSummary | null> {
+  const result = await upstashCommand<string | null>(["GET", location.statusKey]);
+  if (!result) {
+    return null;
+  }
+
+  return JSON.parse(result) as StoredFailureSummary;
+}
+
+export async function getStoredFailureState(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+}): Promise<DiagramStateResponse | null> {
+  for (const location of getReadLocations(params)) {
+    const summary = await getSummaryForLocation(location);
+    if (summary) {
+      return toDiagramStateResponse(summary);
+    }
+  }
+
+  return null;
+}
+
+export async function writeFailureSummary(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+  visibility: ArtifactVisibility;
+  latestSessionSummary: GenerationSessionAudit;
+}): Promise<void> {
+  const location =
+    params.visibility === "private"
+      ? getPrivateLocation(params.username, params.repo, params.githubPat ?? "")
+      : getPublicLocation(params.username, params.repo);
+
+  const summary: StoredFailureSummary = {
+    version: 1,
+    visibility: params.visibility,
+    username: params.username,
+    repo: params.repo,
+    latestSessionSummary: params.latestSessionSummary,
+  };
+
+  await upstashCommand([
+    "SET",
+    location.statusKey,
+    JSON.stringify(summary),
+    "EX",
+    STATUS_TTL_SECONDS,
+  ]);
+}
+
+export async function clearFailureSummary(params: {
+  username: string;
+  repo: string;
+  githubPat?: string;
+  visibility: ArtifactVisibility;
+}): Promise<void> {
+  const location =
+    params.visibility === "private"
+      ? getPrivateLocation(params.username, params.repo, params.githubPat ?? "")
+      : getPublicLocation(params.username, params.repo);
+
+  await upstashCommand(["DEL", location.statusKey]);
+}

--- a/src/server/storage/types.ts
+++ b/src/server/storage/types.ts
@@ -1,0 +1,25 @@
+import type { GenerationSessionAudit } from "~/features/diagram/graph";
+
+export type ArtifactVisibility = "public" | "private";
+
+export interface DiagramArtifact {
+  version: 1;
+  visibility: ArtifactVisibility;
+  username: string;
+  repo: string;
+  diagram: string;
+  explanation: string;
+  graph: GenerationSessionAudit["graph"];
+  generatedAt: string;
+  usedOwnKey: boolean;
+  latestSessionSummary: GenerationSessionAudit;
+  lastSuccessfulAt: string;
+}
+
+export interface StoredFailureSummary {
+  version: 1;
+  visibility: ArtifactVisibility;
+  username: string;
+  repo: string;
+  latestSessionSummary: GenerationSessionAudit;
+}

--- a/src/server/storage/upstash.ts
+++ b/src/server/storage/upstash.ts
@@ -1,0 +1,49 @@
+import { readRequiredEnv } from "~/server/storage/config";
+
+function getBaseUrl() {
+  return readRequiredEnv("UPSTASH_REDIS_REST_URL").replace(/\/$/, "");
+}
+
+function getHeaders(): HeadersInit {
+  return {
+    Authorization: `Bearer ${readRequiredEnv("UPSTASH_REDIS_REST_TOKEN")}`,
+    "Content-Type": "application/json",
+  };
+}
+
+async function execute<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(`${getBaseUrl()}${path}`, {
+    method: "POST",
+    headers: getHeaders(),
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Upstash request failed (${response.status}): ${await response.text()}`,
+    );
+  }
+
+  const payload = (await response.json()) as { result?: T; error?: string };
+  if (payload.error) {
+    throw new Error(`Upstash command failed: ${payload.error}`);
+  }
+
+  return payload.result as T;
+}
+
+export async function upstashCommand<T>(command: unknown[]): Promise<T> {
+  return execute<T>("", command);
+}
+
+export async function upstashEval<T>(params: {
+  script: string;
+  keys?: string[];
+  args?: Array<string | number>;
+}): Promise<T> {
+  return execute<T>("/eval", {
+    script: params.script,
+    keys: params.keys ?? [],
+    args: params.args ?? [],
+  });
+}


### PR DESCRIPTION
## Summary
- move diagram artifact storage from Neon/Postgres to Cloudflare R2
- move complimentary quota and lightweight failure summaries from Postgres to Upstash Redis
- keep Railway as the long-running FastAPI generation backend while cutting production runtime off Neon
- add public-cache backfill tooling and operational status scripts for the one-time migration

## Why
Neon compute had become the dominant infra cost for GitDiagram because public cache reads were repeatedly waking the database. The cache itself is a much better fit for object storage, and quota/failure metadata is a much better fit for lightweight key-value storage.

This PR brings the codebase in line with the production cutover that already happened:
- Vercel frontend reads diagram artifacts from R2
- Railway FastAPI generation backend writes artifacts to R2 and quota/status state to Upstash
- production runtime no longer requires `POSTGRES_URL`

## What Changed
### Shared storage architecture
- add `src/server/storage/*` for:
  - R2 artifact reads/writes
  - Upstash quota operations
  - Upstash failure-summary persistence
  - public/private cache key derivation
  - backend selection/config helpers
- add object-storage-backed diagram state reads in [src/server/db/diagram-state.ts](/Users/ahmedkhaleel/repos/gitdiagram/src/server/db/diagram-state.ts)
- preserve the existing frontend response shape so the UI does not need a breaking API change

### Next.js runtime changes
- route cached diagram reads through object storage first
- persist only terminal generation outcomes instead of repeated intermediate audit writes
- keep complimentary quota behavior but route it through Upstash when configured
- make `POSTGRES_URL` optional in Next env validation
- update GitHub repo metadata fetches to expose visibility so public/private storage routing is explicit

### FastAPI / Railway runtime changes
- extend `DiagramStateRepository` to support:
  - R2 artifacts
  - Upstash quota state
  - Upstash failure summaries
  - object/dual/postgres backend modes
- update GitHub service metadata to include repo visibility
- add required backend deps and lockfile updates for the new storage path

### Migration tooling
- add one-time public backfill scripts:
  - `scripts/backfill-public-cache-to-r2.mjs`
  - `scripts/backfill-public-cache-loop.mjs`
  - `scripts/backfill-public-cache-daemon.mjs`
  - `scripts/backfill-public-cache-status.mjs`
- backfill behavior:
  - migrate public rows only
  - skip invalid Mermaid
  - skip newer existing R2 objects
  - skip missing repos
  - synthesize terminal success summaries for legacy cache rows
- update `scripts/complimentary-quota-today.mjs` to support the new quota backend

### Defaults and envs
- update `.env.example` to reflect the new default architecture:
  - `DIAGRAM_CACHE_BACKEND=object`
  - `QUOTA_BACKEND=upstash`
  - `POSTGRES_FALLBACK_ENABLED=false`
- keep `POSTGRES_URL` documented as optional for one-time backfills and legacy inspection only
- make runtime defaults prefer the new stores when configured, but still fall back sanely in isolated test environments

## Migration Outcome
The production migration completed before opening this PR.

Backfill results:
- processed: `88,187`
- uploaded to R2: `66,803`
- skipped: `21,353`
- invalid Mermaid skipped: `14,568`
- repo not found skipped: `5,641`
- newer object already existed: `1,144`

Current object-store footprint after cutover:
- R2 public bucket: `68,996` objects, about `651.9 MB`
- R2 private bucket: `0` objects
- Upstash footprint: effectively empty except active quota state

## Verification
- `pnpm exec tsc --noEmit`
- `uv run pytest -q`
- `curl https://gitdiagram.com/api/healthz`
- `curl https://gitdiagram-api-production.up.railway.app/healthz`
- object-backed read probes succeeded under both Railway and Vercel production envs
- production cost route probe succeeded:
  - `POST /generate/cost` for `openai/openai-node`

## Production Notes
Production is already running on:
- Vercel frontend
- Railway FastAPI backend
- Cloudflare R2 for diagram artifacts
- Upstash Redis for quota/failure state
- no Neon/Postgres in runtime

After merge, the remaining operational follow-up is external cleanup:
- revoke temporary GitHub PATs
- remove/cancel the old Neon integration/project if archival retention is no longer needed
