### PR TITLE
Fix Upstash eval quota commands

### DIFF
--- a/backend/app/services/diagram_state_repository.py
+++ b/backend/app/services/diagram_state_repository.py
@@ -163,9 +163,9 @@ class DiagramStateRepository:
         if not self.upstash_url:
             raise ValueError("Missing Upstash configuration.")
         response = requests.post(
-            f"{self.upstash_url.rstrip('/')}/eval",
+            self.upstash_url.rstrip("/"),
             headers=self._upstash_headers(),
-            json={"script": script, "keys": keys, "args": args},
+            json=["EVAL", script, len(keys), *keys, *args],
             timeout=30,
         )
         response.raise_for_status()

--- a/src/server/storage/upstash.ts
+++ b/src/server/storage/upstash.ts
@@ -41,9 +41,7 @@ export async function upstashEval<T>(params: {
   keys?: string[];
   args?: Array<string | number>;
 }): Promise<T> {
-  return execute<T>("/eval", {
-    script: params.script,
-    keys: params.keys ?? [],
-    args: params.args ?? [],
-  });
+  const keys = params.keys ?? [];
+  const args = params.args ?? [];
+  return execute<T>("", ["EVAL", params.script, keys.length, ...keys, ...args]);
 }


### PR DESCRIPTION
## Summary
- fix Upstash Lua quota operations to use the Redis REST command form for `EVAL`
- stop sending the unsupported custom `/eval` JSON object payload in both the Next and FastAPI runtimes

## Root Cause
Upstash Redis REST expects `EVAL` to be sent as a normal Redis command array:
- `['EVAL', script, numkeys, ...keys, ...args]`

The migration had implemented `upstashEval` using a custom `/eval` JSON payload with `{ script, keys, args }`, which Upstash rejected with:
- `ERR wrong number of arguments for 'eval' command`

That broke complimentary quota reservations at the very start of generation.

## Verification
- real Upstash probe against the live database succeeded for reserve + finalize
- `pnpm exec tsc --noEmit`
- `cd backend && uv run pytest -q`
- live stream probe on Railway got past quota reservation and into explanation streaming
