### PR TITLE
[codex] Add Renovate config for PostHog updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Keep PostHog npm packages current, but wait a few days before merging new releases.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["posthog-js", "@posthog/**"],
+      "minimumReleaseAge": "3 days",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Require a manual check before major PostHog upgrades.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["posthog-js", "@posthog/**"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Added a Renovate config focused on PostHog packages.
- Patch and minor PostHog npm updates can auto-merge after a 3-day waiting period.
- Major PostHog updates require manual approval.

## Why

- This keeps PostHog current without relying on manual updates.
- The 3-day delay reduces exposure to bad package publishes.

## Impact

- After Renovate is enabled for the repo, it will open dependency PRs automatically.
- Small PostHog updates can merge themselves once checks pass and GitHub auto-merge is enabled.

## Validation

- Validated renovate.json syntax with jq.
