### PR TITLE
[codex] Expand Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,74 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
+    directories:
+      - "/"
+      - "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Toronto"
+    cooldown:
+      default-days: 3
+    groups:
+      javascript-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        group-by: "dependency-name"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "uv"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:15"
+      timezone: "America/Toronto"
+    cooldown:
+      default-days: 3
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    allow:
-      - dependency-name: "posthog-js"
-      - dependency-name: "@posthog/*"
+      day: "monday"
+      time: "09:30"
+      timezone: "America/Toronto"
+    cooldown:
+      default-days: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:45"
+      timezone: "America/Toronto"
     cooldown:
       default-days: 3
     labels:
       - "dependencies"
-      - "posthog"
+      - "docker"


### PR DESCRIPTION
## What changed

- Expanded Dependabot beyond PostHog-only updates.
- Added coverage for Bun dependencies in the root app and backend package.json.
- Added coverage for backend Python dependencies via uv.
- Added coverage for GitHub Actions and the backend Dockerfile.
- Grouped minor and patch JS and Python updates to reduce PR noise.

## Why

- This gives the repo a standard GitHub-native dependency update setup.
- Breaking major updates stay more visible because they are not grouped with smaller changes.

## Validation

- Validated .github/dependabot.yml parses as YAML.
