### PR TITLE
Tune Dependabot update timing and uv coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    cooldown:
+      default-days: 3
     ignore:
       - dependency-name: "eslint"
         update-types:
@@ -26,21 +28,31 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "uv"
     directory: "/backend"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    cooldown:
+      default-days: 3
+    allow:
+      - dependency-type: "all"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "docker"
     directory: "/backend"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## Summary
- add a 3-day Dependabot cooldown across ecosystems
- let the backend uv entry include indirect lockfile dependencies
- keep the existing eslint major ignore in place

## Why
This makes Dependabot wait a few days before picking up brand-new releases while still keeping security updates fast, and it makes backend transitive uv.lock updates eligible for normal Dependabot version updates.