### PR TITLE
FIX: ensure single GITHUB_PAT works when GITHUB_PATS is undefined

### DIFF
--- a/src/server/github-auth.ts
+++ b/src/server/github-auth.ts
@@ -67,17 +67,18 @@ export function hasGitHubAppAuth() {
 }
 
 export function readGitHubPatPool() {
-  const tokenPool = process.env.GITHUB_PATS?.split(/[,\n]/u)
+  const tokenPool = (process.env.GITHUB_PATS?.split(/[,\n]/u) ?? [])
     .map((token) => token.trim())
     .filter(Boolean);
 
   const singleToken = readTrimmedEnv("GITHUB_PAT");
   if (singleToken) {
-    tokenPool?.push(singleToken);
+    tokenPool.push(singleToken);
   }
 
-  return Array.from(new Set(tokenPool ?? []));
+  return Array.from(new Set(tokenPool));
 }
+
 
 export async function getGitHubAppInstallationToken() {
   if (


### PR DESCRIPTION

### What changed?
---
Fixed an issue where a single GITHUB_PAT is silently ignored when GITHUB_PATS is undefined.

### Why?
---
Previously, if GITHUB_PATS was not set, tokenPool would end up as undefined. The code then used tokenPool?.push(singleToken), which silently skipped adding the single token and returned an empty array. By initializing tokenPool with a fallback (?? []), we ensure it is always an array and GITHUB_PAT is correctly added.