### PR TITLE
Block forged Server Action probes

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { NextRequest } from "next/server";
+
+import { config, proxy } from "~/proxy";
+
+describe("proxy", () => {
+  it("rejects forged Server Action requests without caching the response", () => {
+    const response = proxy(
+      new NextRequest("https://gitdiagram.com/", {
+        method: "POST",
+        headers: { "Next-Action": "x" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("allows ordinary requests as defense in depth", () => {
+    const response = proxy(new NextRequest("https://gitdiagram.com/"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("matches only requests carrying the Server Action header", () => {
+    expect(config).toEqual({
+      matcher: [
+        {
+          source: "/:path*",
+          has: [{ type: "header", key: "next-action" }],
+        },
+      ],
+    });
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const REJECTION_HEADERS = {
+  "Cache-Control": "no-store",
+  "X-Content-Type-Options": "nosniff",
+};
+
+/**
+ * GitDiagram does not expose Server Actions. Reject forged action requests at
+ * the proxy boundary so they never reach the Next.js action decoder.
+ */
+export function proxy(request: NextRequest): NextResponse {
+  if (!request.headers.has("next-action")) {
+    return NextResponse.next();
+  }
+
+  return new NextResponse(null, {
+    status: 404,
+    headers: REJECTION_HEADERS,
+  });
+}
+
+export const config = {
+  matcher: [
+    {
+      source: "/:path*",
+      has: [{ type: "header", key: "next-action" }],
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- reject requests carrying `Next-Action` because GitDiagram exposes no Server Actions
- use a header-only Next.js 16 Proxy matcher so normal traffic bypasses Proxy entirely
- return a non-cacheable 404 before the action decoder

## Verification
- focused proxy tests
- TypeScript
- ESLint
- production build

This hardens the Railway standby after live scanners sent fake `Next-Action: x` requests.