### PR TITLE
Align Next.js ISR builds with Vercel's Bun runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can also replace `hub` with `diagram` in a GitHub URL to open its diagram.
 ## Stack
 
 - **Application:** Next.js 16 App Router, React 19, TypeScript, Tailwind CSS, and Radix UI
-- **Generation API:** same-origin Next.js Route Handlers running on Vercel's Node.js runtime
+- **Generation API:** same-origin Next.js Route Handlers running on Vercel's Bun runtime
 - **Storage:** Cloudflare R2 for diagram artifacts
 - **Coordination:** Upstash Redis for quota accounting, cancellation, locks, and short-lived failure state
 - **AI:** OpenAI, OpenRouter, or Atlas Cloud through `AI_PROVIDER`

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -107,7 +107,7 @@ The test suite includes real Mermaid parser contract tests for the deterministic
 
 ## Deploy
 
-The primary deployment is Vercel with Bun as the package manager and the Node.js runtime for Route Handlers. Add the variables from `.env.example` to the Vercel project, then deploy:
+The primary deployment is Vercel with Bun as both the package manager and the server runtime for Route Handlers. The route-level `runtime = "nodejs"` declarations select Next.js's server runtime rather than Edge; the project-level `bunVersion` setting makes Vercel execute those Functions with Bun. Add the variables from `.env.example` to the Vercel project, then deploy:
 
 ```bash
 vercel deploy

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "next build",
+    "build": "bun run --bun next build",
     "check": "bun run lint && bun run typecheck",
     "dev": "./scripts/dev-turbo.sh",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/scripts/dev-turbo.sh
+++ b/scripts/dev-turbo.sh
@@ -16,4 +16,4 @@ restore_tty() {
 # Always restore terminal modes when the dev server exits, including SIGINT.
 trap restore_tty EXIT INT TERM
 
-next dev --turbo "$@"
+bun run --bun next dev --turbo "$@"


### PR DESCRIPTION
## Summary
- invoke Next.js build explicitly through Bun as required for ISR with Vercel bunVersion
- run the wrapped Next.js dev command through Bun too
- make runtime documentation match the deployed Vercel configuration

## Verification
- bun run lint
- bun run typecheck
- bun run test (176 tests)
- bun run build
- bun run dev --help