### PR TITLE
Remove former standby domains from test fixtures

### DIFF
--- a/src/app/api/diagram-state/route.test.ts
+++ b/src/app/api/diagram-state/route.test.ts
@@ -58,7 +58,7 @@ describe("POST /api/diagram-state", () => {
     );
   });
 
-  it("accepts the public origin behind Railway's trusted proxy", async () => {
+  it("accepts the public origin behind a trusted reverse proxy", async () => {
     mocks.getDiagramStateRecord.mockResolvedValue({
       diagram: null,
       explanation: null,
@@ -71,8 +71,8 @@ describe("POST /api/diagram-state", () => {
       request(
         { username: "octocat", repo: "Hello-World" },
         {
-          Origin: "https://standby.gitdiagram.com",
-          "X-Forwarded-Host": "standby.gitdiagram.com",
+          Origin: "https://self-hosted.example.test",
+          "X-Forwarded-Host": "self-hosted.example.test",
           "X-Forwarded-Proto": "https",
         },
         "http://0.0.0.0:8080/api/diagram-state",

--- a/src/app/api/generate/cancel/route.test.ts
+++ b/src/app/api/generate/cancel/route.test.ts
@@ -56,13 +56,13 @@ describe("POST /api/generate/cancel", () => {
     );
   });
 
-  it("accepts the public origin behind Railway's trusted proxy", async () => {
+  it("accepts the public origin behind a trusted reverse proxy", async () => {
     const response = await POST(
       request(
         { session_id: sessionId, cancel_token: cancelToken },
         {
-          Origin: "https://api.gitdiagram.com",
-          "X-Forwarded-Host": "api.gitdiagram.com",
+          Origin: "https://self-hosted.example.test",
+          "X-Forwarded-Host": "self-hosted.example.test",
           "X-Forwarded-Proto": "https",
         },
         "http://0.0.0.0:8080/api/generate/cancel",

--- a/src/server/http/same-origin.test.ts
+++ b/src/server/http/same-origin.test.ts
@@ -24,9 +24,9 @@ describe("isSameOriginRequest", () => {
       isSameOriginRequest(
         request("http://0.0.0.0:8080/api/diagram-state", {
           host: "0.0.0.0:8080",
-          origin: "https://standby.gitdiagram.com",
+          origin: "https://self-hosted.example.test",
           "sec-fetch-site": "same-origin",
-          "x-forwarded-host": "standby.gitdiagram.com",
+          "x-forwarded-host": "self-hosted.example.test",
           "x-forwarded-proto": "https",
         }),
       ),
@@ -37,8 +37,8 @@ describe("isSameOriginRequest", () => {
     expect(
       isSameOriginRequest(
         request("http://0.0.0.0:8080/api/generate/cancel", {
-          origin: "https://api.gitdiagram.com",
-          "x-forwarded-host": "api.gitdiagram.com, internal.local:8080",
+          origin: "https://self-hosted.example.test",
+          "x-forwarded-host": "self-hosted.example.test, internal.local:8080",
           "x-forwarded-proto": "https, http",
         }),
       ),
@@ -51,7 +51,7 @@ describe("isSameOriginRequest", () => {
         request("http://0.0.0.0:8080/api/diagram-state", {
           origin: "https://attacker.example",
           "sec-fetch-site": "same-origin",
-          "x-forwarded-host": "standby.gitdiagram.com",
+          "x-forwarded-host": "self-hosted.example.test",
           "x-forwarded-proto": "https",
         }),
       ),
@@ -62,7 +62,7 @@ describe("isSameOriginRequest", () => {
     expect(
       isSameOriginRequest(
         request("http://0.0.0.0:8080/api/diagram-state", {
-          origin: "https://standby.gitdiagram.com",
+          origin: "https://self-hosted.example.test",
           "sec-fetch-site": "same-origin",
           "x-forwarded-host": "attacker.example",
           "x-forwarded-proto": "https",
@@ -75,9 +75,9 @@ describe("isSameOriginRequest", () => {
     expect(
       isSameOriginRequest(
         request("http://0.0.0.0:8080/api/diagram-state", {
-          origin: "https://standby.gitdiagram.com",
+          origin: "https://self-hosted.example.test",
           "sec-fetch-site": "same-origin",
-          "x-forwarded-host": "standby.gitdiagram.com",
+          "x-forwarded-host": "self-hosted.example.test",
           "x-forwarded-proto": "http",
         }),
       ),
@@ -88,9 +88,9 @@ describe("isSameOriginRequest", () => {
     expect(
       isSameOriginRequest(
         request("http://0.0.0.0:8080/api/diagram-state", {
-          origin: "https://standby.gitdiagram.com",
+          origin: "https://self-hosted.example.test",
           "sec-fetch-site": "same-origin",
-          "x-forwarded-host": "standby.gitdiagram.com",
+          "x-forwarded-host": "self-hosted.example.test",
         }),
       ),
     ).toBe(false);


### PR DESCRIPTION
## Summary
- replace former Railway domain names with reserved `.test` hosts
- keep reverse-proxy same-origin coverage without implying a live standby

## Verification
- affected tests: 17 passed
- bun run lint
- git diff --check