### PR TITLE
Polish motion and modernize example diagrams

### DIFF
--- a/animation-plans/001-responsive-control-motion.md
+++ b/animation-plans/001-responsive-control-motion.md
@@ -1,0 +1,70 @@
+# 001 — Unify responsive control motion
+
+- **Status**: DONE
+- **Commit**: 3078b4b
+- **Severity**: HIGH
+- **Category**: Purpose, frequency, cohesion, accessibility
+- **Estimated scope**: 4 files, small
+
+## Problem
+
+Shared controls use weak built-in easing and inconsistent motion. In
+`src/styles/globals.css:123-170`, the three neo-brutalist control classes use
+`transform 0.2s ease`, lift on every hover-capable selector, and have no press
+or reduced-motion behavior. Frequent header navigation also moves upward in
+`src/components/header-client.tsx:101-128` and
+`src/components/theme-toggle.tsx:17`.
+
+```css
+/* src/styles/globals.css:128 — current */
+transition:
+  transform 0.2s ease,
+  background-color 0.2s ease;
+```
+
+## Target
+
+Add the shared curves to `:root`:
+
+```css
+--ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+--ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+--ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+```
+
+Use `transform 160ms var(--ease-out)` for control movement. Add a subtle
+`scale(0.97)` press state. Put lift-on-hover behavior inside
+`@media (hover: hover) and (pointer: fine)`. Frequent header navigation should
+transition color only, not position. Under `prefers-reduced-motion: reduce`,
+keep color/opacity feedback and remove transform movement.
+
+## Repo conventions to follow
+
+- Shared neo-brutalist component styles live in `src/styles/globals.css`.
+- Generic button variants live in `src/components/ui/button.tsx`.
+- Preserve the existing black offset shadows and purple palette.
+
+## Steps
+
+1. Add the three exact easing tokens to both themes through the shared `:root`.
+2. Update neo control transition durations/easing and add press feedback.
+3. Gate lift-on-hover styles behind fine hover pointers.
+4. Remove upward hover transforms from frequent header and theme controls.
+5. Add reduced-motion fallbacks that retain color/opacity feedback.
+
+## Boundaries
+
+- Do not change spacing, colors, borders, shadows, or markup.
+- Do not add a motion library.
+- Do not animate keyboard-triggered navigation.
+
+## Verification
+
+- **Mechanical**: `bun run check` and `bun run test` pass.
+- **Feel check**: mouse press on a primary, muted, and browse button reads as a
+  subtle compression; touch does not leave a lifted hover state; header links
+  no longer hop vertically.
+- Toggle reduced motion and confirm presses retain opacity/color feedback with
+  no scale/translation.
+- **Done when**: control motion uses shared tokens and no frequent nav item
+  translates on hover.

--- a/animation-plans/002-mobile-menu-transition.md
+++ b/animation-plans/002-mobile-menu-transition.md
@@ -1,0 +1,60 @@
+# 002 — Give the mobile menu a spatial transition
+
+- **Status**: DONE
+- **Commit**: 3078b4b
+- **Severity**: MEDIUM
+- **Category**: Missed opportunity, physicality, interruptibility
+- **Estimated scope**: 2 files, medium
+
+## Problem
+
+The occasional mobile menu is conditionally mounted in
+`src/components/header-client.tsx:143-209`, so both the backdrop and panel
+teleport in and out with no spatial connection to the Menu trigger.
+
+```tsx
+{isMobileMenuOpen ? (
+  <>
+    <button className="fixed inset-0 z-40 bg-black/30 sm:hidden" />
+    <div className="pointer-events-none fixed inset-x-4 top-[4.5rem] ...">
+```
+
+## Target
+
+Keep the layer mounted with `data-state="open|closed"`. Fade the backdrop in
+over `180ms` and out over `140ms`. Transition the panel from
+`opacity: 0; transform: translateY(-8px) scale(0.97)` to its settled state over
+`200ms var(--ease-out)`, and close over `140ms var(--ease-out)`. Set
+`transform-origin: top right`. Delay hidden visibility until the exit finishes
+so the transition is interruptible. Closed content must be inert and removed
+from the accessibility tree.
+
+## Repo conventions to follow
+
+- Reuse `.neo-panel` and `.browse-muted-button` without restyling them.
+- Reuse `--ease-out` from plan 001.
+
+## Steps
+
+1. Render the mobile menu layer unconditionally with open/closed data state.
+2. Make the closed menu inert, aria-hidden, non-interactive, and invisible
+   after its exit completes.
+3. Add scoped backdrop/panel transitions in `src/styles/globals.css`.
+4. Under reduced motion, keep a short opacity fade and remove transform motion.
+
+## Boundaries
+
+- Do not animate individual menu rows or the icon swap.
+- Do not change menu contents, stacking order, or responsive breakpoints.
+- Do not add a dependency.
+
+## Verification
+
+- **Mechanical**: `bun run check` and header tests pass.
+- **Feel check**: at 390x844, open and rapidly close/reopen the menu. It should
+  retarget smoothly from its current state and clearly originate below the
+  trigger. At 10% playback, no frame should jump from or to `scale(0)`.
+- Toggle reduced motion: the backdrop/panel may fade, but must not translate or
+  scale.
+- **Done when**: the menu has symmetric spatial direction, faster exit, and no
+  closed-state focus targets.

--- a/animation-plans/003-tooltip-dialog-motion.md
+++ b/animation-plans/003-tooltip-dialog-motion.md
@@ -1,0 +1,59 @@
+# 003 — Tighten tooltip and dialog motion
+
+- **Status**: DONE
+- **Commit**: 3078b4b
+- **Severity**: MEDIUM
+- **Category**: Easing, duration, origin, accessibility
+- **Estimated scope**: 5 files, medium
+
+## Problem
+
+`src/components/ui/tooltip.tsx:23-26` animates every tooltip for `300ms` with
+generic keyframes and no trigger-aware transform origin. Each consumer creates
+its own provider (`src/components/action-button.tsx:25-45` and
+`src/components/copy-button.tsx:25-53`), so adjacent tooltips cannot use Radix's
+instant-open state. Dialogs also use the same `300ms` timing for open and close
+in `src/components/ui/dialog.tsx:20-38` and have no reduced-motion branch.
+
+## Target
+
+Wrap the app once with `TooltipProvider delayDuration={500}` and
+`skipDelayDuration={300}`. Tooltips use
+`transform-origin: var(--radix-tooltip-content-transform-origin)`, enter from
+`scale(0.97)` + opacity over `150ms var(--ease-out)`, exit over `100ms`, and set
+transition duration to zero for `data-state="instant-open"`. Reduced motion
+drops scale but retains opacity.
+
+Dialog content opens over `220ms var(--ease-out)` and closes over `160ms`; the
+overlay uses `180ms` open / `140ms` close. Reduced motion keeps fade but removes
+zoom. Modals remain center-origin.
+
+## Repo conventions to follow
+
+- Provider composition lives in `src/app/providers.tsx`.
+- Radix UI wrappers live under `src/components/ui/`.
+- Reuse `--ease-out` from plan 001.
+
+## Steps
+
+1. Add one app-level tooltip provider with Radix delay props.
+2. Remove nested providers from the two tooltip consumers.
+3. Replace tooltip animation utility classes with a scoped, origin-aware CSS
+   transition using `@starting-style` for mount entry.
+4. Tighten dialog open/close durations and add reduced-motion zoom overrides.
+
+## Boundaries
+
+- Do not change tooltip copy, placement, collision logic, or modal layout.
+- Do not use `scale(0)`.
+- Do not animate layout properties.
+
+## Verification
+
+- **Mechanical**: `bun run check` and `bun run test` pass.
+- **Feel check**: first tooltip waits, then appears in under 200ms from its
+  trigger; moving to the adjacent tooltip opens instantly without replaying the
+  animation. Dialog close is visibly faster than open.
+- Inspect at 10% playback and confirm tooltip origin follows its trigger.
+- Toggle reduced motion and confirm only opacity changes.
+- **Done when**: small popovers are fast, origin-aware, shared, and accessible.

--- a/animation-plans/004-legible-state-motion.md
+++ b/animation-plans/004-legible-state-motion.md
@@ -1,0 +1,71 @@
+# 004 — Make state changes legible without moving data
+
+- **Status**: DONE
+- **Commit**: 3078b4b
+- **Severity**: HIGH
+- **Category**: Purpose, performance, cohesion
+- **Estimated scope**: 4 files, medium
+
+## Problem
+
+The export panel in `src/components/main-card.tsx:177-193` uses
+`transition-all` while changing `max-height`, which animates layout. Its two
+chevrons swap abruptly. Copy feedback in `src/components/copy-button.tsx:32-42`
+teleports between labels and changes button width. Conversely, functional
+Mermaid nodes scale on every hover in `src/components/mermaid-diagram.tsx:305-315`,
+moving data the user is trying to inspect.
+
+```tsx
+className={`transition-all duration-200 ${
+  activeDropdown ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
+}`}
+```
+
+## Target
+
+Delete the layout animation. Mount export content only while open and give it a
+GPU-only `@starting-style` entrance from `opacity: 0; transform:
+translateY(-4px) scale(0.99)` over `180ms var(--ease-out)`. Use one chevron and
+rotate it `180deg` over `160ms var(--ease-in-out)` as state indication.
+
+Keep both copy-button labels in the same grid cell so width is stable. Crossfade
+them over `160ms var(--ease-out)` with at most `filter: blur(2px)` and a `2px`
+vertical offset. Reduced motion keeps opacity and removes offset/blur. Announce
+success through a polite live region.
+
+Remove transform animation and hover scaling from clickable Mermaid nodes;
+direct manipulation and readable graph geometry take priority.
+
+Replace the generation status dots' positional bounce with a staggered opacity
+pulse so loading still feels active without moving information.
+
+## Repo conventions to follow
+
+- Reuse existing Tailwind layout utilities and the shared easing tokens.
+- Preserve existing copy, icons, callbacks, and export content.
+
+## Steps
+
+1. Replace the export wrapper and two-icon swap with a conditional GPU-only
+   entrance and a single rotating chevron.
+2. Make copy feedback width-stable and crossfade the two states in one grid.
+3. Add a polite screen-reader success announcement.
+4. Remove hover scale and transform transition from Mermaid's theme CSS.
+5. Replace bouncing generation dots with staggered opacity pulses.
+6. Add reduced-motion fallbacks for both new state transitions.
+
+## Boundaries
+
+- Do not animate the diagram, graph rows, pan/zoom, or route changes.
+- Do not change export behavior or copy timeout.
+- Do not animate height, width, margin, padding, top, or left.
+
+## Verification
+
+- **Mechanical**: `bun run check`, `bun run test`, and `bun run build` pass.
+- **Feel check**: export appears without layout animation; rapid toggles never
+  restart a keyframe. Copying keeps button geometry fixed and reads as one
+  content morph. Hovering a Mermaid node does not move graph geometry.
+- Toggle reduced motion and confirm only opacity/color feedback remains.
+- **Done when**: no `transition-all` or animated graph scaling remains and state
+  changes are legible without moving functional data.

--- a/animation-plans/README.md
+++ b/animation-plans/README.md
@@ -1,0 +1,14 @@
+# GitDiagram animation plans
+
+These plans were audited against the UI at commit `3078b4b`. Execute them in
+order: the shared motion vocabulary in 001 is reused by every later plan.
+
+| Plan | Title                                          | Severity | Status |
+| ---- | ---------------------------------------------- | -------- | ------ |
+| 001  | Unify responsive control motion                | HIGH     | DONE   |
+| 002  | Give the mobile menu a spatial transition      | MEDIUM   | DONE   |
+| 003  | Tighten tooltip and dialog motion              | MEDIUM   | DONE   |
+| 004  | Make state changes legible without moving data | HIGH     | DONE   |
+
+Dependencies: 002-004 depend on the easing tokens introduced by 001. The
+plans do not add a motion dependency; predetermined motion stays in CSS.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "bun run --bun next build",
     "check": "bun run lint && bun run typecheck",
     "dev": "./scripts/dev-turbo.sh",
+    "examples:migrate": "bun scripts/migrate-example-diagrams.ts",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "preview": "next build && next start",

--- a/scripts/generate-example-previews.ts
+++ b/scripts/generate-example-previews.ts
@@ -1,0 +1,320 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { GenerationTokenUsage } from "../src/features/diagram/cost";
+import {
+  diagramGraphSchema,
+  MAX_GRAPH_ATTEMPTS,
+  type DiagramGraph,
+} from "../src/features/diagram/graph";
+import {
+  EXPLANATION_MAX_OUTPUT_TOKENS,
+  EXPLANATION_REASONING_EFFORT,
+  EXPLANATION_TEXT_VERBOSITY,
+  GRAPH_MAX_OUTPUT_TOKENS,
+  GRAPH_REASONING_EFFORT,
+  GRAPH_TEXT_VERBOSITY,
+} from "../src/server/generate/generation-policy";
+import {
+  extractTaggedSection,
+  toTaggedMessage,
+} from "../src/server/generate/format";
+import { getGithubData } from "../src/server/generate/github";
+import {
+  buildFileTreeLookup,
+  compileDiagramGraph,
+  formatGraphValidationFeedback,
+  validateDiagramGraph,
+} from "../src/server/generate/graph";
+import { getModel, getProvider } from "../src/server/generate/model-config";
+import { validateMermaidSyntax } from "../src/server/generate/mermaid";
+import {
+  generateStructuredOutput,
+  streamCompletion,
+} from "../src/server/generate/openai";
+import {
+  SYSTEM_FIRST_PROMPT,
+  SYSTEM_GRAPH_PROMPT,
+} from "../src/server/generate/prompts";
+
+const examples = [
+  { username: "fastapi", repo: "fastapi" },
+  { username: "streamlit", repo: "streamlit" },
+  { username: "pallets", repo: "flask" },
+  { username: "tom-draper", repo: "api-analytics" },
+  { username: "monkeytypegame", repo: "monkeytype" },
+] as const;
+
+type Example = (typeof examples)[number];
+
+interface PreviewAttempt {
+  attempt: number;
+  valid: boolean;
+  validationFeedback?: string;
+  usage: GenerationTokenUsage | null;
+}
+
+interface ExamplePreview {
+  username: string;
+  repo: string;
+  defaultBranch: string;
+  generatedAt: string;
+  durationMs: number;
+  explanation: string;
+  graph: DiagramGraph;
+  diagram: string;
+  graphAttempts: PreviewAttempt[];
+  explanationUsage: GenerationTokenUsage | null;
+}
+
+interface PreviewFailure {
+  username: string;
+  repo: string;
+  message: string;
+}
+
+interface PreviewFile {
+  generatedAt: string;
+  provider: string;
+  model: string;
+  previews: ExamplePreview[];
+  failures: PreviewFailure[];
+}
+
+const outputDirectory = path.join(
+  process.cwd(),
+  "tmp",
+  "example-generation-previews",
+);
+const provider = getProvider();
+const model = getModel(provider);
+const runStartedAt = new Date().toISOString();
+const runDirectory = path.join(
+  outputDirectory,
+  runStartedAt.replace(/[:.]/gu, "-"),
+);
+const concurrency = Math.max(
+  1,
+  Math.min(
+    examples.length,
+    Number.parseInt(process.env.EXAMPLE_PREVIEW_CONCURRENCY ?? "2", 10) || 2,
+  ),
+);
+
+const previews: ExamplePreview[] = [];
+const failures: PreviewFailure[] = [];
+
+async function writeJsonAtomically(filePath: string, value: unknown) {
+  const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await rename(temporaryPath, filePath);
+}
+
+async function persistPreviewState() {
+  const payload: PreviewFile = {
+    generatedAt: runStartedAt,
+    provider,
+    model,
+    previews: examples.flatMap((example) => {
+      const preview = previews.find(
+        (candidate) =>
+          candidate.username === example.username &&
+          candidate.repo === example.repo,
+      );
+      return preview ? [preview] : [];
+    }),
+    failures: [...failures],
+  };
+
+  await writeJsonAtomically(path.join(runDirectory, "previews.json"), payload);
+  await writeJsonAtomically(path.join(outputDirectory, "latest.json"), payload);
+}
+
+async function generatePreview(example: Example): Promise<ExamplePreview> {
+  const label = `${example.username}/${example.repo}`;
+  const startedAt = performance.now();
+  const requestId = `example-preview-${randomUUID()}`;
+  const signal = AbortSignal.timeout(220_000);
+
+  console.log(`[${label}] Fetching current GitHub repository data...`);
+  const githubData = await getGithubData(
+    example.username,
+    example.repo,
+    undefined,
+    signal,
+  );
+
+  console.log(
+    `[${label}] Generating architecture explanation with ${model}...`,
+  );
+  let explanationResponse = "";
+  const explanationStream = await streamCompletion({
+    provider,
+    model,
+    systemPrompt: SYSTEM_FIRST_PROMPT,
+    userPrompt: toTaggedMessage({
+      file_tree: githubData.fileTree,
+      readme: githubData.readme,
+    }),
+    reasoningEffort: EXPLANATION_REASONING_EFFORT,
+    textVerbosity: EXPLANATION_TEXT_VERBOSITY,
+    maxOutputTokens: EXPLANATION_MAX_OUTPUT_TOKENS,
+    signal,
+    clientRequestId: `${requestId}:explanation`,
+  });
+
+  for await (const chunk of explanationStream.stream) {
+    explanationResponse += chunk;
+  }
+  const explanationUsage = await explanationStream.usagePromise.catch(
+    () => null,
+  );
+  const explanation = extractTaggedSection(explanationResponse, "explanation");
+  if (!explanation.trim()) {
+    throw new Error("Explanation generation returned no usable output.");
+  }
+
+  const fileTreeLookup = buildFileTreeLookup(githubData.fileTree);
+  const graphAttempts: PreviewAttempt[] = [];
+  let validGraph: DiagramGraph | null = null;
+  let validationFeedback: string | undefined;
+  let previousGraphRaw: string | undefined;
+
+  for (let attempt = 1; attempt <= MAX_GRAPH_ATTEMPTS; attempt++) {
+    console.log(
+      `[${label}] Planning graph (attempt ${attempt}/${MAX_GRAPH_ATTEMPTS})...`,
+    );
+    const {
+      output: graph,
+      rawText,
+      usage,
+    } = await generateStructuredOutput({
+      provider,
+      model,
+      systemPrompt: SYSTEM_GRAPH_PROMPT,
+      userPrompt: toTaggedMessage(
+        attempt === 1
+          ? { explanation }
+          : {
+              explanation,
+              file_tree: githubData.fileTree,
+              previous_graph: previousGraphRaw,
+              validation_feedback: validationFeedback,
+            },
+      ),
+      schema: diagramGraphSchema,
+      schemaName: "diagram_graph",
+      reasoningEffort: GRAPH_REASONING_EFFORT,
+      textVerbosity: GRAPH_TEXT_VERBOSITY,
+      maxOutputTokens: GRAPH_MAX_OUTPUT_TOKENS,
+      signal,
+      clientRequestId: `${requestId}:graph:${attempt}`,
+    });
+
+    const validation = validateDiagramGraph(graph, fileTreeLookup);
+    validationFeedback = validation.valid
+      ? undefined
+      : formatGraphValidationFeedback(validation.issues);
+    graphAttempts.push({
+      attempt,
+      valid: validation.valid,
+      validationFeedback,
+      usage,
+    });
+
+    if (validation.valid) {
+      validGraph = graph;
+      break;
+    }
+
+    previousGraphRaw = rawText;
+    console.log(`[${label}] Graph validation requested a repair.`);
+  }
+
+  if (!validGraph) {
+    throw new Error(
+      validationFeedback ??
+        "Graph generation failed validation after all repair attempts.",
+    );
+  }
+
+  const diagram = compileDiagramGraph({
+    graph: validGraph,
+    username: example.username,
+    repo: example.repo,
+    branch: githubData.defaultBranch,
+  });
+  const mermaidValidation = await validateMermaidSyntax(diagram);
+  if (!mermaidValidation.valid) {
+    throw new Error(
+      `Compiled Mermaid failed validation: ${mermaidValidation.message ?? "unknown error"}`,
+    );
+  }
+
+  const preview: ExamplePreview = {
+    username: example.username,
+    repo: example.repo,
+    defaultBranch: githubData.defaultBranch,
+    generatedAt: new Date().toISOString(),
+    durationMs: Math.round(performance.now() - startedAt),
+    explanation,
+    graph: validGraph,
+    diagram,
+    graphAttempts,
+    explanationUsage,
+  };
+  console.log(
+    `[${label}] Complete: ${validGraph.nodes.length} nodes, ${validGraph.edges.length} edges, ${validGraph.groups.length} groups.`,
+  );
+  return preview;
+}
+
+async function main() {
+  await mkdir(runDirectory, { recursive: true });
+  console.log(
+    `Generating ${examples.length} preview-only example diagrams with ${provider}/${model} (concurrency ${concurrency}).`,
+  );
+
+  const queue = [...examples];
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (queue.length) {
+      const example = queue.shift();
+      if (!example) return;
+
+      try {
+        previews.push(await generatePreview(example));
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown generation error.";
+        failures.push({ ...example, message });
+        console.error(
+          `[${example.username}/${example.repo}] Failed: ${message}`,
+        );
+      }
+
+      await persistPreviewState();
+    }
+  });
+
+  await Promise.all(workers);
+  await persistPreviewState();
+
+  console.log(
+    JSON.stringify(
+      {
+        output: path.join(outputDirectory, "latest.json"),
+        generated: previews.length,
+        failed: failures.length,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (failures.length) {
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/scripts/migrate-example-diagrams.ts
+++ b/scripts/migrate-example-diagrams.ts
@@ -1,0 +1,203 @@
+import { modernizeLegacyMermaidSource } from "../src/features/diagram/mermaid-modernize";
+import { validateMermaidSyntax } from "../src/server/generate/mermaid";
+import { getPublicLocation } from "../src/server/storage/cache-key";
+import { getJsonObject, putJsonObject } from "../src/server/storage/r2";
+import type { DiagramArtifact } from "../src/server/storage/types";
+
+const examples = [
+  { username: "fastapi", repo: "fastapi" },
+  { username: "streamlit", repo: "streamlit" },
+  { username: "pallets", repo: "flask" },
+  { username: "tom-draper", repo: "api-analytics" },
+  { username: "monkeytypegame", repo: "monkeytype" },
+] as const;
+
+const apply = process.argv.includes("--apply");
+const restoreRoot = process.argv
+  .find((argument) => argument.startsWith("--restore="))
+  ?.slice("--restore=".length);
+const timestamp = new Date()
+  .toISOString()
+  .replace(/[-:]/gu, "")
+  .replace(/\.\d{3}Z$/u, "Z");
+const backupRoot = `migration-backups/example-mermaid-modernization/${timestamp}`;
+
+function extractClickUrls(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /^\s*click\s+[A-Za-z_][A-Za-z0-9_-]*\s+"(https:\/\/github\.com\/[^"\s]+)"\s*$/gmu,
+    ),
+    (match) => match[1] ?? "",
+  );
+}
+
+async function main() {
+  if (restoreRoot) {
+    for (const example of examples) {
+      const location = getPublicLocation(example.username, example.repo);
+      const backupKey = `${restoreRoot}/${location.artifactKey}`;
+      const backup = await getJsonObject<DiagramArtifact>(
+        location.bucket,
+        backupKey,
+      );
+      if (!backup) {
+        throw new Error(`Missing migration backup at ${backupKey}.`);
+      }
+      await putJsonObject(location.bucket, location.artifactKey, backup);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          mode: "restored",
+          backupRoot: restoreRoot,
+          examples: examples.map(({ username, repo }) => `${username}/${repo}`),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const prepared = [];
+
+  for (const example of examples) {
+    const location = getPublicLocation(example.username, example.repo);
+    const artifact = await getJsonObject<DiagramArtifact>(
+      location.bucket,
+      location.artifactKey,
+    );
+    if (!artifact) {
+      throw new Error(
+        `Missing artifact for ${example.username}/${example.repo}.`,
+      );
+    }
+
+    const modernization = modernizeLegacyMermaidSource(artifact.diagram);
+    const beforeClickUrls = extractClickUrls(artifact.diagram);
+    const afterClickUrls = extractClickUrls(modernization.source);
+    if (JSON.stringify(afterClickUrls) !== JSON.stringify(beforeClickUrls)) {
+      throw new Error(
+        `Click URLs changed for ${example.username}/${example.repo}.`,
+      );
+    }
+
+    const validation = await validateMermaidSyntax(modernization.source);
+    if (!validation.valid) {
+      throw new Error(
+        `Modernized Mermaid is invalid for ${example.username}/${example.repo}: ${validation.message}`,
+      );
+    }
+
+    prepared.push({
+      example,
+      location,
+      artifact,
+      migratedArtifact: { ...artifact, diagram: modernization.source },
+      modernization,
+      backupKey: `${backupRoot}/${location.artifactKey}`,
+    });
+  }
+
+  if (!apply) {
+    console.log(
+      JSON.stringify(
+        {
+          mode: "dry-run",
+          examples: prepared.map(({ example, modernization }) => ({
+            repo: `${example.username}/${example.repo}`,
+            changed: modernization.changed,
+            nodes: modernization.nodeCount,
+            groups: modernization.groupCount,
+            clicks: modernization.clickCount,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  for (const entry of prepared) {
+    const current = await getJsonObject<DiagramArtifact>(
+      entry.location.bucket,
+      entry.location.artifactKey,
+    );
+    if (JSON.stringify(current) !== JSON.stringify(entry.artifact)) {
+      throw new Error(
+        `Artifact changed during migration preparation: ${entry.example.username}/${entry.example.repo}.`,
+      );
+    }
+  }
+
+  for (const entry of prepared) {
+    await putJsonObject(entry.location.bucket, entry.backupKey, entry.artifact);
+  }
+
+  const written: typeof prepared = [];
+  try {
+    for (const entry of prepared) {
+      await putJsonObject(
+        entry.location.bucket,
+        entry.location.artifactKey,
+        entry.migratedArtifact,
+      );
+      written.push(entry);
+    }
+  } catch (error) {
+    const rollbackErrors: unknown[] = [];
+    for (const entry of written.reverse()) {
+      try {
+        await putJsonObject(
+          entry.location.bucket,
+          entry.location.artifactKey,
+          entry.artifact,
+        );
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+
+    if (rollbackErrors.length) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        "Example Mermaid migration failed and rollback was incomplete.",
+      );
+    }
+    throw error;
+  }
+
+  for (const entry of prepared) {
+    const stored = await getJsonObject<DiagramArtifact>(
+      entry.location.bucket,
+      entry.location.artifactKey,
+    );
+    if (JSON.stringify(stored) !== JSON.stringify(entry.migratedArtifact)) {
+      throw new Error(
+        `Post-write verification failed for ${entry.example.username}/${entry.example.repo}.`,
+      );
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: "applied",
+        backupRoot,
+        examples: prepared.map(({ example, modernization, backupKey }) => ({
+          repo: `${example.username}/${example.repo}`,
+          nodes: modernization.nodeCount,
+          groups: modernization.groupCount,
+          clicks: modernization.clickCount,
+          backupKey,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+await main();

--- a/scripts/promote-example-diagram-previews.ts
+++ b/scripts/promote-example-diagram-previews.ts
@@ -1,0 +1,318 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import type { GenerationSessionAudit } from "../src/features/diagram/graph";
+import { validateMermaidSyntax } from "../src/server/generate/mermaid";
+import { updatePublicBrowseIndexForSuccessfulDiagram } from "../src/server/storage/diagram-state";
+import { getPublicLocation } from "../src/server/storage/cache-key";
+import { getJsonObject, putJsonObject } from "../src/server/storage/r2";
+import type { DiagramArtifact } from "../src/server/storage/types";
+
+const examples = [
+  { username: "fastapi", repo: "fastapi" },
+  { username: "streamlit", repo: "streamlit" },
+  { username: "pallets", repo: "flask" },
+  { username: "tom-draper", repo: "api-analytics" },
+  { username: "monkeytypegame", repo: "monkeytype" },
+] as const;
+
+interface PreviewFile {
+  generatedAt: string;
+  provider: string;
+  model: string;
+  previews: Array<{
+    username: string;
+    repo: string;
+    generatedAt: string;
+    explanation: string;
+    graph: NonNullable<DiagramArtifact["graph"]>;
+    diagram: string;
+  }>;
+  failures: Array<{ username: string; repo: string; message: string }>;
+}
+
+const apply = process.argv.includes("--apply");
+const restoreRoot = process.argv
+  .find((argument) => argument.startsWith("--restore="))
+  ?.slice("--restore=".length);
+const timestamp = new Date()
+  .toISOString()
+  .replace(/[-:]/gu, "")
+  .replace(/\.\d{3}Z$/u, "Z");
+const backupRoot = `backups/example-diagrams/before-generated-pipeline/${timestamp}`;
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function restoreArtifacts(root: string) {
+  const prepared = [];
+
+  for (const example of examples) {
+    const location = getPublicLocation(example.username, example.repo);
+    const backupKey = `${root}/${location.artifactKey}`;
+    const artifact = await getJsonObject<DiagramArtifact>(
+      location.bucket,
+      backupKey,
+    );
+    if (!artifact) {
+      throw new Error(`Missing rollback artifact at ${backupKey}.`);
+    }
+    prepared.push({ example, location, artifact, backupKey });
+  }
+
+  for (const entry of prepared) {
+    await putJsonObject(
+      entry.location.bucket,
+      entry.location.artifactKey,
+      entry.artifact,
+    );
+  }
+
+  for (const entry of prepared) {
+    const stored = await getJsonObject<DiagramArtifact>(
+      entry.location.bucket,
+      entry.location.artifactKey,
+    );
+    if (JSON.stringify(stored) !== JSON.stringify(entry.artifact)) {
+      throw new Error(
+        `Rollback verification failed for ${entry.example.username}/${entry.example.repo}.`,
+      );
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: "restored",
+        backupRoot: root,
+        examples: prepared.map(({ example, artifact }) => ({
+          repo: `${example.username}/${example.repo}`,
+          diagramSha: sha256(artifact.diagram),
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function main() {
+  if (restoreRoot) {
+    await restoreArtifacts(restoreRoot);
+    return;
+  }
+
+  const previewFile = JSON.parse(
+    await readFile("tmp/example-generation-previews/latest.json", "utf8"),
+  ) as PreviewFile;
+  if (previewFile.failures.length) {
+    throw new Error(
+      "The preview run contains failures and cannot be promoted.",
+    );
+  }
+
+  const prepared = [];
+  for (const example of examples) {
+    const preview = previewFile.previews.find(
+      (candidate) =>
+        candidate.username === example.username &&
+        candidate.repo === example.repo,
+    );
+    if (!preview) {
+      throw new Error(
+        `Missing preview for ${example.username}/${example.repo}.`,
+      );
+    }
+
+    const validation = await validateMermaidSyntax(preview.diagram);
+    if (!validation.valid) {
+      throw new Error(
+        `Invalid preview Mermaid for ${example.username}/${example.repo}: ${validation.message}`,
+      );
+    }
+
+    const location = getPublicLocation(example.username, example.repo);
+    const artifact = await getJsonObject<DiagramArtifact>(
+      location.bucket,
+      location.artifactKey,
+    );
+    if (!artifact) {
+      throw new Error(
+        `Missing current artifact for ${example.username}/${example.repo}.`,
+      );
+    }
+
+    const latestSessionSummary: GenerationSessionAudit = {
+      sessionId: `example-preview:${example.username}/${example.repo}:${preview.generatedAt}`,
+      status: "succeeded",
+      stage: "complete",
+      provider: previewFile.provider,
+      model: previewFile.model,
+      graph: preview.graph,
+      graphAttempts: [],
+      stageUsages: [],
+      timeline: [],
+      createdAt: preview.generatedAt,
+      updatedAt: preview.generatedAt,
+    };
+    const promotedArtifact: DiagramArtifact = {
+      ...artifact,
+      diagram: preview.diagram,
+      explanation: preview.explanation,
+      graph: preview.graph,
+      generatedAt: preview.generatedAt,
+      usedOwnKey: false,
+      latestSessionSummary,
+      lastSuccessfulAt: preview.generatedAt,
+    };
+
+    prepared.push({
+      example,
+      preview,
+      location,
+      artifact,
+      promotedArtifact,
+      backupKey: `${backupRoot}/${location.artifactKey}`,
+    });
+  }
+
+  if (!apply) {
+    console.log(
+      JSON.stringify(
+        {
+          mode: "dry-run",
+          provider: previewFile.provider,
+          model: previewFile.model,
+          backupRoot,
+          examples: prepared.map(({ example, artifact, promotedArtifact }) => ({
+            repo: `${example.username}/${example.repo}`,
+            oldDiagramSha: sha256(artifact.diagram),
+            newDiagramSha: sha256(promotedArtifact.diagram),
+            oldNodes: artifact.graph?.nodes.length ?? null,
+            newNodes: promotedArtifact.graph?.nodes.length ?? null,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  for (const entry of prepared) {
+    const current = await getJsonObject<DiagramArtifact>(
+      entry.location.bucket,
+      entry.location.artifactKey,
+    );
+    if (JSON.stringify(current) !== JSON.stringify(entry.artifact)) {
+      throw new Error(
+        `Artifact changed during promotion preparation: ${entry.example.username}/${entry.example.repo}.`,
+      );
+    }
+  }
+
+  for (const entry of prepared) {
+    await putJsonObject(entry.location.bucket, entry.backupKey, entry.artifact);
+  }
+  await putJsonObject(
+    prepared[0]!.location.bucket,
+    `${backupRoot}/manifest.json`,
+    {
+      version: 1,
+      createdAt: new Date().toISOString(),
+      purpose:
+        "Rollback snapshot before promoting freshly generated example diagrams.",
+      provider: previewFile.provider,
+      model: previewFile.model,
+      examples: prepared.map(
+        ({ example, backupKey, artifact, promotedArtifact }) => ({
+          repo: `${example.username}/${example.repo}`,
+          backupKey,
+          oldDiagramSha: sha256(artifact.diagram),
+          promotedDiagramSha: sha256(promotedArtifact.diagram),
+        }),
+      ),
+    },
+  );
+
+  const written: typeof prepared = [];
+  try {
+    for (const entry of prepared) {
+      await putJsonObject(
+        entry.location.bucket,
+        entry.location.artifactKey,
+        entry.promotedArtifact,
+      );
+      written.push(entry);
+    }
+  } catch (error) {
+    const rollbackErrors: unknown[] = [];
+    for (const entry of written.reverse()) {
+      try {
+        await putJsonObject(
+          entry.location.bucket,
+          entry.location.artifactKey,
+          entry.artifact,
+        );
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+    if (rollbackErrors.length) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        "Example promotion failed and automatic rollback was incomplete.",
+      );
+    }
+    throw error;
+  }
+
+  for (const entry of prepared) {
+    const stored = await getJsonObject<DiagramArtifact>(
+      entry.location.bucket,
+      entry.location.artifactKey,
+    );
+    if (JSON.stringify(stored) !== JSON.stringify(entry.promotedArtifact)) {
+      throw new Error(
+        `Post-write verification failed for ${entry.example.username}/${entry.example.repo}.`,
+      );
+    }
+  }
+
+  const browseIndexErrors: string[] = [];
+  for (const entry of prepared) {
+    try {
+      await updatePublicBrowseIndexForSuccessfulDiagram({
+        username: entry.example.username,
+        repo: entry.example.repo,
+        lastSuccessfulAt: entry.promotedArtifact.lastSuccessfulAt,
+        stargazerCount: entry.promotedArtifact.stargazerCount,
+      });
+    } catch (error) {
+      browseIndexErrors.push(
+        `${entry.example.username}/${entry.example.repo}: ${error instanceof Error ? error.message : "unknown error"}`,
+      );
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: "applied",
+        backupRoot,
+        restoreCommand: `bun scripts/promote-example-diagram-previews.ts --restore=${backupRoot}`,
+        examples: prepared.map(({ example, promotedArtifact }) => ({
+          repo: `${example.username}/${example.repo}`,
+          diagramSha: sha256(promotedArtifact.diagram),
+          nodes: promotedArtifact.graph?.nodes.length ?? null,
+        })),
+        browseIndexErrors,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+await main();

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import { ThemeProvider } from "next-themes";
+import { TooltipProvider } from "~/components/ui/tooltip";
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
@@ -54,12 +55,14 @@ export function CSPostHogProvider({ children }: { children: React.ReactNode }) {
       enableSystem={false}
       storageKey="gitdiagram-theme"
     >
-      <PostHogProvider client={posthog}>
-        <Suspense fallback={null}>
-          <PostHogPageviewTracker />
-        </Suspense>
-        {children}
-      </PostHogProvider>
+      <TooltipProvider delayDuration={500} skipDelayDuration={300}>
+        <PostHogProvider client={posthog}>
+          <Suspense fallback={null}>
+            <PostHogPageviewTracker />
+          </Suspense>
+          {children}
+        </PostHogProvider>
+      </TooltipProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/action-button.tsx
+++ b/src/components/action-button.tsx
@@ -3,7 +3,6 @@ import type { LucideIcon } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 
@@ -23,25 +22,23 @@ export function ActionButton({
   text,
 }: ActionButtonProps) {
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            onClick={(e) => {
-              e.preventDefault();
-              onClick();
-            }}
-            disabled={disabled}
-            className="neo-button p-4 px-4 text-base sm:p-6 sm:px-6 sm:text-lg"
-          >
-            <Icon className="h-6 w-6" />
-            {text && <span className="text-sm">{text}</span>}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>{tooltipText}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          onClick={(e) => {
+            e.preventDefault();
+            onClick();
+          }}
+          disabled={disabled}
+          className="neo-button p-4 px-4 text-base sm:p-6 sm:px-6 sm:text-lg"
+        >
+          <Icon className="h-6 w-6" />
+          {text && <span className="text-sm">{text}</span>}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{tooltipText}</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,10 +1,9 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { FileText, Check } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 
@@ -14,42 +13,56 @@ interface CopyButtonProps {
 
 export function CopyButton({ onClick }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleClick = () => {
     onClick();
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000); // Reset after 2 seconds
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+    }
+    resetTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
   };
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            onClick={handleClick}
-            className="neo-button p-4 px-4 text-base sm:p-6 sm:px-6 sm:text-lg"
-          >
-            {copied ? (
-              <>
-                <Check className="h-6 w-6" />
-                <span className="text-sm">Copied!</span>
-              </>
-            ) : (
-              <>
-                <FileText className="h-6 w-6" />
-                <span className="text-sm">Copy Mermaid.js Code</span>
-              </>
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>
-            {copied
-              ? "Copied!"
-              : "Copy the internal Mermaid.js code needed to generate the diagram"}
-          </p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          onClick={handleClick}
+          aria-label={copied ? "Mermaid code copied" : "Copy Mermaid.js code"}
+          className="neo-button p-4 px-4 text-base sm:p-6 sm:px-6 sm:text-lg"
+        >
+          <span className="copy-button-content" aria-hidden="true">
+            <span className="copy-button-state" data-active={!copied}>
+              <FileText className="h-6 w-6" />
+              <span className="text-sm">Copy Mermaid.js Code</span>
+            </span>
+            <span className="copy-button-state" data-active={copied}>
+              <Check className="h-6 w-6" />
+              <span className="text-sm">Copied!</span>
+            </span>
+          </span>
+          <span className="sr-only" aria-live="polite">
+            {copied ? "Mermaid code copied to clipboard" : ""}
+          </span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>
+          {copied
+            ? "Copied!"
+            : "Copy the internal Mermaid.js code needed to generate the diagram"}
+        </p>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/header-client.tsx
+++ b/src/components/header-client.tsx
@@ -98,14 +98,14 @@ export function HeaderClient({ starCount }: HeaderClientProps) {
         <nav className="hidden items-center gap-6 sm:flex">
           <Link
             href="/browse"
-            className="text-sm font-medium text-black transition-transform hover:translate-y-[-2px] hover:text-purple-600 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]"
+            className="text-sm font-medium text-black transition-colors duration-150 hover:text-purple-600 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]"
           >
             Browse
           </Link>
           <button
             type="button"
             onClick={() => setIsApiKeyDialogOpen(true)}
-            className="text-sm font-medium text-black transition-transform hover:translate-y-[-2px] hover:text-purple-600 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]"
+            className="text-sm font-medium text-black transition-colors duration-150 hover:text-purple-600 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]"
           >
             <span className="flex items-center sm:hidden">
               <span>API Key</span>
@@ -117,7 +117,7 @@ export function HeaderClient({ starCount }: HeaderClientProps) {
           <button
             type="button"
             onClick={() => setIsPrivateReposDialogOpen(true)}
-            className="text-sm font-medium text-black transition-transform hover:translate-y-[-2px] hover:text-purple-600 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]"
+            className="text-sm font-medium text-black transition-colors duration-150 hover:text-purple-600 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]"
           >
             <span className="sm:hidden">Private Repos</span>
             <span className="hidden sm:inline">Private Repos</span>
@@ -125,7 +125,7 @@ export function HeaderClient({ starCount }: HeaderClientProps) {
           <ThemeToggle />
           <Link
             href={githubRepoUrl}
-            className="flex items-center gap-1 text-sm font-medium text-black transition-transform hover:translate-y-[-2px] hover:text-purple-600 sm:gap-2 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]"
+            className="flex items-center gap-1 text-sm font-medium text-black transition-colors duration-150 hover:text-purple-600 sm:gap-2 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]"
           >
             <FaGithub className="h-5 w-5" />
             <span className="hidden sm:inline">GitHub</span>
@@ -140,73 +140,77 @@ export function HeaderClient({ starCount }: HeaderClientProps) {
           </Link>
         </nav>
 
-        {isMobileMenuOpen ? (
-          <>
-            <button
-              type="button"
-              aria-label="Close mobile menu"
-              onClick={() => setIsMobileMenuOpen(false)}
-              className="fixed inset-0 z-40 bg-black/30 sm:hidden"
-            />
-            <div className="pointer-events-none fixed inset-x-4 top-[4.5rem] z-50 sm:hidden">
-              <div
-                id="mobile-site-menu"
-                className="neo-panel pointer-events-auto ml-auto w-full max-w-[18rem] rounded-lg p-3"
-              >
-                <nav className="flex flex-col gap-2">
-                  {!isBrowsePage ? (
-                    <Link
-                      href="/browse"
-                      onClick={() => setIsMobileMenuOpen(false)}
-                      className="browse-muted-button inline-flex min-h-[48px] items-center justify-between rounded-md px-4 py-3 text-sm font-semibold"
-                    >
-                      Browse
-                    </Link>
-                  ) : null}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setIsApiKeyDialogOpen(true);
-                      setIsMobileMenuOpen(false);
-                    }}
-                    className="browse-muted-button inline-flex min-h-[48px] items-center justify-between rounded-md px-4 py-3 text-sm font-semibold"
-                  >
-                    API Key
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setIsPrivateReposDialogOpen(true);
-                      setIsMobileMenuOpen(false);
-                    }}
-                    className="browse-muted-button inline-flex min-h-[48px] items-center justify-between rounded-md px-4 py-3 text-sm font-semibold"
-                  >
-                    Private Repos
-                  </button>
-                  <ThemeToggle
-                    onToggle={() => setIsMobileMenuOpen(false)}
-                    className="browse-muted-button inline-flex min-h-[48px] items-center justify-between rounded-md px-4 py-3 text-sm font-semibold"
-                  />
+        <div
+          data-state={isMobileMenuOpen ? "open" : "closed"}
+          aria-hidden={!isMobileMenuOpen}
+          className="mobile-menu-layer fixed inset-0 z-40 sm:hidden"
+        >
+          <button
+            type="button"
+            aria-label="Close mobile menu"
+            tabIndex={isMobileMenuOpen ? 0 : -1}
+            onClick={() => setIsMobileMenuOpen(false)}
+            className="mobile-menu-overlay absolute inset-0 bg-black/30"
+          />
+          <div className="pointer-events-none absolute inset-x-4 top-[4.5rem] z-10">
+            <div
+              id="mobile-site-menu"
+              inert={!isMobileMenuOpen}
+              className="neo-panel mobile-menu-panel pointer-events-auto ml-auto w-full max-w-[18rem] rounded-lg p-3"
+            >
+              <nav className="flex flex-col gap-2">
+                {!isBrowsePage ? (
                   <Link
-                    href={githubRepoUrl}
+                    href="/browse"
                     onClick={() => setIsMobileMenuOpen(false)}
-                    className="browse-muted-button inline-flex min-h-[48px] items-center justify-between gap-3 rounded-md px-4 py-3 text-sm font-semibold"
+                    className="browse-muted-button inline-flex min-h-[48px] items-center justify-between rounded-md px-4 py-3 text-sm font-semibold"
                   >
-                    <span className="flex items-center gap-2">
-                      <FaGithub className="h-5 w-5" />
-                      GitHub Repo
-                    </span>
-                    {starCount !== null ? (
-                      <span className="text-xs tracking-[0.12em] text-[hsl(var(--neo-soft-text))] uppercase dark:text-neutral-300">
-                        {formatStarCount(starCount)}
-                      </span>
-                    ) : null}
+                    Browse
                   </Link>
-                </nav>
-              </div>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsApiKeyDialogOpen(true);
+                    setIsMobileMenuOpen(false);
+                  }}
+                  className="browse-muted-button inline-flex min-h-[48px] items-center justify-between rounded-md px-4 py-3 text-sm font-semibold"
+                >
+                  API Key
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsPrivateReposDialogOpen(true);
+                    setIsMobileMenuOpen(false);
+                  }}
+                  className="browse-muted-button inline-flex min-h-[48px] items-center justify-between rounded-md px-4 py-3 text-sm font-semibold"
+                >
+                  Private Repos
+                </button>
+                <ThemeToggle
+                  onToggle={() => setIsMobileMenuOpen(false)}
+                  className="browse-muted-button inline-flex min-h-[48px] items-center justify-between rounded-md px-4 py-3 text-sm font-semibold"
+                />
+                <Link
+                  href={githubRepoUrl}
+                  onClick={() => setIsMobileMenuOpen(false)}
+                  className="browse-muted-button inline-flex min-h-[48px] items-center justify-between gap-3 rounded-md px-4 py-3 text-sm font-semibold"
+                >
+                  <span className="flex items-center gap-2">
+                    <FaGithub className="h-5 w-5" />
+                    GitHub Repo
+                  </span>
+                  {starCount !== null ? (
+                    <span className="text-xs tracking-[0.12em] text-[hsl(var(--neo-soft-text))] uppercase dark:text-neutral-300">
+                      {formatStarCount(starCount)}
+                    </span>
+                  ) : null}
+                </Link>
+              </nav>
             </div>
-          </>
-        ) : null}
+          </div>
+        </div>
 
         <PrivateReposDialog
           isOpen={isPrivateReposDialogOpen}

--- a/src/components/loading.tsx
+++ b/src/components/loading.tsx
@@ -190,9 +190,9 @@ export default function Loading({
                 </p>
                 <div className="mt-3 flex items-center gap-3 text-xs font-medium text-purple-700 dark:text-[hsl(var(--neo-link-hover))]">
                   <span className="inline-flex gap-1">
-                    <span className="h-2 w-2 animate-bounce rounded-full bg-purple-500 [animation-delay:-0.3s] dark:bg-[hsl(var(--neo-button-hover))]" />
-                    <span className="h-2 w-2 animate-bounce rounded-full bg-purple-500 [animation-delay:-0.15s] dark:bg-[hsl(var(--neo-button-hover))]" />
-                    <span className="h-2 w-2 animate-bounce rounded-full bg-purple-500 dark:bg-[hsl(var(--neo-button-hover))]" />
+                    <span className="h-2 w-2 animate-pulse rounded-full bg-purple-500 [animation-delay:-0.24s] [animation-duration:1.2s] dark:bg-[hsl(var(--neo-button-hover))]" />
+                    <span className="h-2 w-2 animate-pulse rounded-full bg-purple-500 [animation-delay:-0.12s] [animation-duration:1.2s] dark:bg-[hsl(var(--neo-button-hover))]" />
+                    <span className="h-2 w-2 animate-pulse rounded-full bg-purple-500 [animation-duration:1.2s] dark:bg-[hsl(var(--neo-button-hover))]" />
                   </span>
                   <span>{graphPlanningSeconds}s in this step</span>
                 </div>

--- a/src/components/main-card.tsx
+++ b/src/components/main-card.tsx
@@ -9,7 +9,7 @@ import { Sparkles } from "lucide-react";
 import React from "react";
 import { exampleRepos, isExampleRepo } from "~/lib/exampleRepos";
 import { ExportDropdown } from "./export-dropdown";
-import { ChevronUp, ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { Switch } from "~/components/ui/switch";
 import { parseGitHubRepoUrl } from "~/features/diagram/github-url";
 import { SponsorSlot } from "~/components/sponsor-slot";
@@ -100,7 +100,11 @@ export default function MainCard({
           </Button>
         </div>
 
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error ? (
+          <p className="status-message text-sm text-red-600" role="alert">
+            {error}
+          </p>
+        ) : null}
 
         {/* Dropdowns Container */}
         {!isHome && (
@@ -119,7 +123,7 @@ export default function MainCard({
                           ? "Regeneration is disabled for example repositories."
                           : undefined
                       }
-                      className={`flex items-center justify-between gap-2 rounded-md border-[3px] border-black px-4 py-2 font-medium text-black transition-colors sm:max-w-[250px] dark:text-black ${
+                      className={`flex items-center justify-between gap-2 rounded-md border-[3px] border-black px-4 py-2 font-medium text-black transition-[background-color,transform] duration-150 ease-[var(--ease-out)] active:scale-[0.97] motion-reduce:active:scale-100 motion-reduce:active:opacity-80 sm:max-w-[250px] dark:text-black ${
                         isExampleRepoSelected
                           ? "cursor-not-allowed bg-purple-200 opacity-70 dark:bg-[#251b3a] dark:text-[hsl(var(--foreground))]"
                           : "bg-purple-300 hover:bg-purple-400 dark:border-[#2d1d4e] dark:bg-[hsl(var(--neo-subtle-muted))] dark:hover:bg-[hsl(var(--neo-subtle))]"
@@ -142,18 +146,21 @@ export default function MainCard({
                           e.preventDefault();
                           handleDropdownToggle("export");
                         }}
-                        className={`flex cursor-pointer items-center justify-between gap-2 rounded-md border-[3px] border-black px-4 py-2 font-medium text-black transition-colors sm:max-w-[250px] dark:text-black ${
+                        aria-expanded={activeDropdown === "export"}
+                        className={`flex cursor-pointer items-center justify-between gap-2 rounded-md border-[3px] border-black px-4 py-2 font-medium text-black transition-[background-color,transform] duration-150 ease-[var(--ease-out)] active:scale-[0.97] motion-reduce:active:scale-100 motion-reduce:active:opacity-80 sm:max-w-[250px] dark:text-black ${
                           activeDropdown === "export"
                             ? "bg-purple-400 dark:border-[#2d1d4e] dark:bg-[hsl(var(--neo-button))]"
                             : "bg-purple-300 hover:bg-purple-400 dark:border-[#2d1d4e] dark:bg-[hsl(var(--neo-subtle-muted))] dark:hover:bg-[hsl(var(--neo-button-hover))]"
                         }`}
                       >
                         <span>Export Diagram</span>
-                        {activeDropdown === "export" ? (
-                          <ChevronUp size={20} />
-                        ) : (
-                          <ChevronDown size={20} />
-                        )}
+                        <ChevronDown
+                          size={20}
+                          aria-hidden="true"
+                          className={`transition-transform duration-150 ease-[var(--ease-in-out)] motion-reduce:rotate-0 ${
+                            activeDropdown === "export" ? "rotate-180" : ""
+                          }`}
+                        />
                       </button>
                     </div>
                   )}
@@ -175,22 +182,16 @@ export default function MainCard({
                 </div>
 
                 {/* Dropdown Content */}
-                <div
-                  className={`transition-all duration-200 ${
-                    activeDropdown
-                      ? "pointer-events-auto max-h-[500px] opacity-100"
-                      : "pointer-events-none max-h-0 opacity-0"
-                  }`}
-                >
-                  {activeDropdown === "export" && (
+                {activeDropdown === "export" ? (
+                  <div className="export-panel">
                     <ExportDropdown
                       onCopy={onCopy!}
                       lastGenerated={lastGenerated}
                       actualCost={actualCost}
                       onExportImage={onExportImage!}
                     />
-                  )}
-                </div>
+                  </div>
+                ) : null}
               </>
             )}
           </div>
@@ -209,7 +210,7 @@ export default function MainCard({
                     key={name}
                     type="button"
                     variant="outline"
-                    className="border-2 border-black bg-purple-400 text-sm text-black transition-transform hover:-translate-y-0.5 hover:transform hover:bg-purple-300 sm:text-base dark:border-black dark:bg-[hsl(var(--neo-panel-muted))] dark:text-[hsl(var(--foreground))] dark:hover:bg-[hsl(var(--neo-button))] dark:hover:text-[#0d0a19]"
+                    className="border-2 border-black bg-purple-400 text-sm text-black hover:bg-purple-300 sm:text-base dark:border-black dark:bg-[hsl(var(--neo-panel-muted))] dark:text-[hsl(var(--foreground))] dark:hover:bg-[hsl(var(--neo-button))] dark:hover:text-[#0d0a19]"
                     onClick={(e) => handleExampleClick(path, e)}
                   >
                     {name}

--- a/src/components/mermaid-diagram-toolbar.tsx
+++ b/src/components/mermaid-diagram-toolbar.tsx
@@ -24,7 +24,7 @@ export function MermaidDiagramToolbar({
           type="button"
           aria-label="Zoom out"
           disabled={!isPanZoomReady}
-          className="flex h-10 w-10 items-center justify-center text-black transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-100 dark:hover:bg-white/5"
+          className="flex h-10 w-10 items-center justify-center text-black transition-[background-color,transform] duration-150 ease-[var(--ease-out)] hover:bg-black/5 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:active:scale-100 motion-reduce:active:opacity-80 dark:text-neutral-100 dark:hover:bg-white/5"
           onClick={onZoomOut}
         >
           <Minus size={18} />
@@ -36,7 +36,7 @@ export function MermaidDiagramToolbar({
           type="button"
           aria-label="Zoom in"
           disabled={!isPanZoomReady}
-          className="flex h-10 w-10 items-center justify-center text-black transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-100 dark:hover:bg-white/5"
+          className="flex h-10 w-10 items-center justify-center text-black transition-[background-color,transform] duration-150 ease-[var(--ease-out)] hover:bg-black/5 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:active:scale-100 motion-reduce:active:opacity-80 dark:text-neutral-100 dark:hover:bg-white/5"
           onClick={onZoomIn}
         >
           <Plus size={18} />
@@ -45,7 +45,7 @@ export function MermaidDiagramToolbar({
       <button
         type="button"
         disabled={!isPanZoomReady}
-        className="pointer-events-auto inline-flex h-10 items-center gap-2 rounded-full border border-black/10 bg-white/80 px-3 text-[11px] font-semibold tracking-[0.16em] text-black/80 uppercase shadow-[0_10px_30px_rgba(15,23,42,0.14)] ring-1 ring-white/70 backdrop-blur-md transition-colors hover:bg-white/92 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/10 dark:bg-[#101722]/78 dark:text-neutral-100/80 dark:shadow-[0_12px_32px_rgba(0,0,0,0.32)] dark:ring-white/10 dark:hover:bg-[#18202c]/92"
+        className="pointer-events-auto inline-flex h-10 items-center gap-2 rounded-full border border-black/10 bg-white/80 px-3 text-[11px] font-semibold tracking-[0.16em] text-black/80 uppercase shadow-[0_10px_30px_rgba(15,23,42,0.14)] ring-1 ring-white/70 backdrop-blur-md transition-[background-color,transform] duration-150 ease-[var(--ease-out)] hover:bg-white/92 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:active:scale-100 motion-reduce:active:opacity-80 dark:border-white/10 dark:bg-[#101722]/78 dark:text-neutral-100/80 dark:shadow-[0_12px_32px_rgba(0,0,0,0.32)] dark:ring-white/10 dark:hover:bg-[#18202c]/92"
         onClick={onFit}
       >
         <ScanSearch size={16} />

--- a/src/components/mermaid-diagram.test.tsx
+++ b/src/components/mermaid-diagram.test.tsx
@@ -111,6 +111,27 @@ describe("MermaidChart", () => {
     });
   });
 
+  it("only gives clickable diagram nodes hover feedback", async () => {
+    render(<MermaidChart chart="flowchart TD\nA-->B" zoomingEnabled={false} />);
+
+    await waitFor(() => {
+      expect(initializeMock).toHaveBeenCalled();
+    });
+
+    const config = initializeMock.mock.calls.at(-1)?.[0] as
+      | { themeCSS?: string }
+      | undefined;
+
+    expect(config?.themeCSS).toContain(".clickable:hover > *");
+    expect(config?.themeCSS).not.toContain(".node:hover");
+    expect(config?.themeCSS).toContain("scale: 1.05");
+    expect(config?.themeCSS).toContain("transition: scale 160ms");
+    expect(config?.themeCSS).toContain("transform-origin: center");
+    expect(config?.themeCSS).toContain(".clickable");
+    expect(config?.themeCSS).toContain("cursor: pointer");
+    expect(config?.themeCSS).toContain("prefers-reduced-motion: reduce");
+  });
+
   it("keeps vertical touch scrolling enabled in read-only mode", () => {
     const { container } = render(
       <MermaidChart chart="flowchart TD\nA-->B" zoomingEnabled={false} />,

--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -303,15 +303,28 @@ const MermaidChart = ({
             tertiaryColor: "#f7f7f7",
           },
       themeCSS: `
-        .clickable {
-          transition: transform 0.2s ease;
+        .clickable > * {
+          scale: 1;
+          transform-box: fill-box;
+          transform-origin: center;
+          transition: scale 160ms cubic-bezier(0.23, 1, 0.32, 1);
         }
-        .clickable:hover {
-          transform: scale(1.05);
+        .clickable {
           cursor: pointer;
         }
-        .clickable:hover > * {
-          filter: brightness(0.85);
+        @media (hover: hover) and (pointer: fine) {
+          .clickable:hover > * {
+            scale: 1.05;
+            filter: brightness(0.85);
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .clickable > * {
+            transition: none;
+          }
+          .clickable:hover > * {
+            scale: 1;
+          }
         }
       `,
     };

--- a/src/components/sponsor-slot.tsx
+++ b/src/components/sponsor-slot.tsx
@@ -102,7 +102,7 @@ export function SponsorSlot({ surface, className }: SponsorSlotProps) {
       {...linkProps(sponsor.href)}
       aria-label={copy.label}
       className={cn(
-        "group flex items-center gap-3 rounded-md border-[2px] border-black bg-[hsl(var(--neo-input-bg))] px-3 py-2 text-left shadow-[3px_3px_0_0_#000] transition-transform hover:-translate-y-0.5 dark:bg-[hsl(var(--neo-panel-muted))]",
+        "neo-lift group flex items-center gap-3 rounded-md border-[2px] border-black bg-[hsl(var(--neo-input-bg))] px-3 py-2 text-left shadow-[3px_3px_0_0_#000] dark:bg-[hsl(var(--neo-panel-muted))]",
         surface === "diagram" &&
           "w-full border-[3px] bg-[hsl(var(--neo-panel))] p-3 shadow-[4px_4px_0_0_#000] dark:bg-[hsl(var(--neo-panel))]",
         className,
@@ -165,7 +165,7 @@ export function SponsorCatalogRow() {
               </span>
             </span>
           </span>
-          <p className="inline-flex min-h-[40px] shrink-0 items-center justify-center gap-2 rounded-md border-[2px] border-black bg-[hsl(var(--neo-button))] px-4 py-2 text-sm font-black text-black shadow-[3px_3px_0_0_#000] transition-transform group-hover:-translate-y-0.5">
+          <p className="inline-flex min-h-[40px] shrink-0 items-center justify-center gap-2 rounded-md border-[2px] border-black bg-[hsl(var(--neo-button))] px-4 py-2 text-sm font-black text-black shadow-[3px_3px_0_0_#000]">
             {sponsor.cta}
             <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
           </p>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -14,7 +14,7 @@ export function ThemeToggle({ className, onToggle }: ThemeToggleProps) {
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const baseClassName =
-    "text-sm font-medium text-black transition-transform hover:translate-y-[-2px] hover:text-purple-600 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]";
+    "text-sm font-medium text-black transition-colors duration-150 hover:text-purple-600 dark:text-neutral-200 dark:hover:text-[hsl(var(--neo-link-hover))]";
 
   useEffect(() => {
     setMounted(true);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "~/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[background-color,border-color,color,opacity,transform] duration-150 ease-[var(--ease-out)] active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:pointer-events-none disabled:opacity-50 motion-reduce:active:scale-100 motion-reduce:active:opacity-80 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -34,7 +34,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "dialog-overlay fixed inset-0 z-50 bg-black/80",
       className,
     )}
     {...props}
@@ -34,13 +34,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "dialog-content bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg origin-center translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -70,7 +70,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "text-lg leading-none font-semibold tracking-tight",
       className,
     )}
     {...props}
@@ -84,16 +84,10 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-muted-foreground text-sm", className)}
     {...props}
   />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
-export {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-};
+export { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -19,10 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md",
-      "duration-300 animate-in fade-in-0 zoom-in-95",
-      "duration-300 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-      "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "tooltip-content bg-popover text-popover-foreground z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md",
       className,
     )}
     {...props}

--- a/src/features/diagram/mermaid-modernize.test.ts
+++ b/src/features/diagram/mermaid-modernize.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { modernizeLegacyMermaidSource } from "~/features/diagram/mermaid-modernize";
+
+describe("modernizeLegacyMermaidSource", () => {
+  it("normalizes legacy identifiers without changing labels, links, or structure", () => {
+    const source = [
+      "graph TB",
+      '  subgraph Client["Client Layer"]',
+      '    CORE["FastAPI Application Core"]:::core',
+      "    CLI[CLI Interface]:::utility",
+      "  end",
+      "  CORE --> CLI",
+      '  click CORE "https://github.com/FastAPI/FastAPI/blob/master/fastapi/applications.py"',
+      "  style Client fill:#fff,stroke:#000",
+      "  class CORE,CLI core",
+    ].join("\n");
+
+    const result = modernizeLegacyMermaidSource(source);
+
+    expect(result.source).toBe(
+      [
+        "flowchart TB",
+        '  subgraph group_client["Client Layer"]',
+        '    node_core["FastAPI Application Core"]:::core',
+        "    node_cli[CLI Interface]:::utility",
+        "  end",
+        "  node_core --> node_cli",
+        '  click node_core "https://github.com/FastAPI/FastAPI/blob/master/fastapi/applications.py"',
+        "  style group_client fill:#fff,stroke:#000",
+        "  class node_core,node_cli core",
+      ].join("\n"),
+    );
+    expect(result).toMatchObject({
+      changed: true,
+      nodeCount: 2,
+      groupCount: 1,
+      clickCount: 1,
+    });
+  });
+
+  it("assigns explicit current-format IDs to quoted subgraphs", () => {
+    const result = modernizeLegacyMermaidSource(
+      [
+        "graph TB",
+        '  subgraph "Frontend Layer"',
+        '    App["App"]',
+        "  end",
+      ].join("\n"),
+    );
+
+    expect(result.source).toContain(
+      'subgraph group_frontend_layer["Frontend Layer"]',
+    );
+    expect(result.source).toContain('node_app["App"]');
+  });
+
+  it("removes legacy init directives that the current renderer ignores", () => {
+    const result = modernizeLegacyMermaidSource(
+      [
+        "%%{init: {",
+        "  'theme': 'base'",
+        "}}%%",
+        "",
+        "flowchart TB",
+        'App["App"]',
+      ].join("\n"),
+    );
+
+    expect(result.source).toBe(["flowchart TB", 'node_app["App"]'].join("\n"));
+  });
+
+  it("is idempotent for current-format Mermaid source", () => {
+    const source = [
+      "flowchart TB",
+      'subgraph group_client["Client Layer"]',
+      '  node_app["App"]',
+      "end",
+      'click node_app "https://github.com/acme/demo/blob/main/app.ts"',
+    ].join("\n");
+
+    const result = modernizeLegacyMermaidSource(source);
+
+    expect(result.source).toBe(source);
+    expect(result.changed).toBe(false);
+  });
+
+  it("rejects node identifiers that collapse to the same current-format ID", () => {
+    expect(() =>
+      modernizeLegacyMermaidSource(
+        ["graph TB", 'FooBar["One"]', 'Foo_Bar["Two"]'].join("\n"),
+      ),
+    ).toThrow("Mermaid node identifiers collide at node_foo_bar");
+  });
+});

--- a/src/features/diagram/mermaid-modernize.ts
+++ b/src/features/diagram/mermaid-modernize.ts
@@ -1,0 +1,260 @@
+const explicitSubgraphPattern =
+  /^(\s*)subgraph\s+([A-Za-z_][A-Za-z0-9_-]*)(?:\s*\["((?:\\.|[^"\\])*)"\])?\s*$/u;
+const quotedSubgraphPattern = /^(\s*)subgraph\s+"((?:\\.|[^"\\])*)"\s*$/u;
+const nodeDeclarationPattern =
+  /^(\s*)([A-Za-z_][A-Za-z0-9_-]*)(?=\s*(?:\[|\(|\{|>))/u;
+const modernNodeIdPattern = /^node_[a-z][a-z0-9_]*$/u;
+const modernGroupIdPattern = /^group_[a-z][a-z0-9_]*$/u;
+
+interface SubgraphDeclaration {
+  indent: string;
+  label: string;
+  newId: string;
+  oldId: string | null;
+}
+
+export interface MermaidModernizationResult {
+  source: string;
+  changed: boolean;
+  nodeRenames: Record<string, string>;
+  groupRenames: Record<string, string>;
+  nodeCount: number;
+  groupCount: number;
+  clickCount: number;
+}
+
+function toSnakeCase(value: string): string {
+  const normalized = value
+    .replace(/([a-z0-9])([A-Z])/gu, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/gu, "$1_$2")
+    .replace(/[^A-Za-z0-9]+/gu, "_")
+    .replace(/^_+|_+$/gu, "")
+    .toLowerCase();
+
+  if (!normalized) {
+    throw new Error(
+      `Cannot derive a Mermaid identifier from ${JSON.stringify(value)}.`,
+    );
+  }
+
+  return /^[a-z]/u.test(normalized) ? normalized : `id_${normalized}`;
+}
+
+function modernNodeId(value: string): string {
+  return modernNodeIdPattern.test(value) ? value : `node_${toSnakeCase(value)}`;
+}
+
+function modernGroupId(value: string): string {
+  return modernGroupIdPattern.test(value)
+    ? value
+    : `group_${toSnakeCase(value)}`;
+}
+
+function reserveUniqueId(base: string, usedIds: Set<string>): string {
+  if (!usedIds.has(base)) {
+    usedIds.add(base);
+    return base;
+  }
+
+  let suffix = 2;
+  while (usedIds.has(`${base}_${suffix}`)) {
+    suffix += 1;
+  }
+
+  const uniqueId = `${base}_${suffix}`;
+  usedIds.add(uniqueId);
+  return uniqueId;
+}
+
+function replaceKnownIdentifiers(
+  line: string,
+  replacements: ReadonlyMap<string, string>,
+): string {
+  let result = "";
+  let index = 0;
+  let inDoubleQuote = false;
+  let inPipeLabel = false;
+  let squareDepth = 0;
+  let roundDepth = 0;
+  let curlyDepth = 0;
+
+  while (index < line.length) {
+    const character = line[index] ?? "";
+    const previous = index > 0 ? line[index - 1] : "";
+
+    if (character === '"' && previous !== "\\") {
+      inDoubleQuote = !inDoubleQuote;
+      result += character;
+      index += 1;
+      continue;
+    }
+
+    if (!inDoubleQuote) {
+      if (
+        character === "|" &&
+        squareDepth === 0 &&
+        roundDepth === 0 &&
+        curlyDepth === 0
+      ) {
+        inPipeLabel = !inPipeLabel;
+      } else if (!inPipeLabel) {
+        if (character === "[") squareDepth += 1;
+        if (character === "]") squareDepth = Math.max(0, squareDepth - 1);
+        if (character === "(") roundDepth += 1;
+        if (character === ")") roundDepth = Math.max(0, roundDepth - 1);
+        if (character === "{") curlyDepth += 1;
+        if (character === "}") curlyDepth = Math.max(0, curlyDepth - 1);
+      }
+    }
+
+    const canReplace =
+      !inDoubleQuote &&
+      !inPipeLabel &&
+      squareDepth === 0 &&
+      roundDepth === 0 &&
+      curlyDepth === 0 &&
+      /[A-Za-z_]/u.test(character);
+
+    if (!canReplace) {
+      result += character;
+      index += 1;
+      continue;
+    }
+
+    let end = index + 1;
+    while (end < line.length && /[A-Za-z0-9_-]/u.test(line[end] ?? "")) {
+      end += 1;
+    }
+
+    const token = line.slice(index, end);
+    result += replacements.get(token) ?? token;
+    index = end;
+  }
+
+  return result;
+}
+
+export function modernizeLegacyMermaidSource(
+  source: string,
+): MermaidModernizationResult {
+  const lines: string[] = [];
+  let insideConfigDirective = false;
+  for (const line of source.split("\n")) {
+    const trimmed = line.trim();
+    if (insideConfigDirective) {
+      insideConfigDirective = !trimmed.includes("}%%");
+      continue;
+    }
+    if (trimmed.startsWith("%%{")) {
+      insideConfigDirective = !trimmed.includes("}%%");
+      continue;
+    }
+    if (!lines.length && !trimmed) {
+      continue;
+    }
+    lines.push(line);
+  }
+  const nodeRenames = new Map<string, string>();
+  const groupRenames = new Map<string, string>();
+  const subgraphs = new Map<number, SubgraphDeclaration>();
+  const usedNodeIds = new Set<string>();
+  const usedGroupIds = new Set<string>();
+
+  for (const [lineIndex, line] of lines.entries()) {
+    const explicitSubgraph = line.match(explicitSubgraphPattern);
+    if (explicitSubgraph) {
+      const [, indent = "", oldId = "", explicitLabel] = explicitSubgraph;
+      const newId = modernGroupId(oldId);
+      const existing = groupRenames.get(oldId);
+      if (existing && existing !== newId) {
+        throw new Error(`Conflicting Mermaid subgraph identifier ${oldId}.`);
+      }
+      if (usedGroupIds.has(newId) && existing !== newId) {
+        throw new Error(`Mermaid subgraph identifiers collide at ${newId}.`);
+      }
+      usedGroupIds.add(newId);
+      groupRenames.set(oldId, newId);
+      subgraphs.set(lineIndex, {
+        indent,
+        label: explicitLabel ?? oldId,
+        newId,
+        oldId,
+      });
+      continue;
+    }
+
+    const quotedSubgraph = line.match(quotedSubgraphPattern);
+    if (quotedSubgraph) {
+      const [, indent = "", label = ""] = quotedSubgraph;
+      subgraphs.set(lineIndex, {
+        indent,
+        label,
+        newId: reserveUniqueId(modernGroupId(label), usedGroupIds),
+        oldId: null,
+      });
+      continue;
+    }
+
+    if (line.trimStart().startsWith("%%")) {
+      continue;
+    }
+
+    const declaration = line.match(nodeDeclarationPattern);
+    if (!declaration) {
+      continue;
+    }
+
+    const oldId = declaration[2] ?? "";
+    const newId = modernNodeId(oldId);
+    const existing = nodeRenames.get(oldId);
+    if (existing && existing !== newId) {
+      throw new Error(`Conflicting Mermaid node identifier ${oldId}.`);
+    }
+    if (usedNodeIds.has(newId) && existing !== newId) {
+      throw new Error(`Mermaid node identifiers collide at ${newId}.`);
+    }
+    usedNodeIds.add(newId);
+    nodeRenames.set(oldId, newId);
+  }
+
+  for (const [oldId, newId] of groupRenames) {
+    const nodeReplacement = nodeRenames.get(oldId);
+    if (nodeReplacement && nodeReplacement !== newId) {
+      throw new Error(
+        `Mermaid identifier ${oldId} is used by both a node and a subgraph.`,
+      );
+    }
+  }
+
+  const replacements = new Map([...groupRenames, ...nodeRenames]);
+  const modernizedLines = lines.map((line, lineIndex) => {
+    const subgraph = subgraphs.get(lineIndex);
+    if (subgraph) {
+      return `${subgraph.indent}subgraph ${subgraph.newId}["${subgraph.label}"]`;
+    }
+
+    if (line.trimStart().startsWith("%%")) {
+      return line;
+    }
+
+    const normalizedHeader = line.replace(/^(\s*)graph\b/u, "$1flowchart");
+    return replaceKnownIdentifiers(normalizedHeader, replacements);
+  });
+
+  const modernizedSource = modernizedLines.join("\n");
+  const clickCount = modernizedLines.filter((line) =>
+    /^\s*click\s+node_[a-z][a-z0-9_]*\s+"https:\/\/github\.com\/[^"\s]+"\s*$/u.test(
+      line,
+    ),
+  ).length;
+
+  return {
+    source: modernizedSource,
+    changed: modernizedSource !== source,
+    nodeRenames: Object.fromEntries(nodeRenames),
+    groupRenames: Object.fromEntries(groupRenames),
+    nodeCount: nodeRenames.size,
+    groupCount: subgraphs.size,
+    clickCount,
+  };
+}

--- a/src/features/diagram/mermaid-security.test.ts
+++ b/src/features/diagram/mermaid-security.test.ts
@@ -13,6 +13,7 @@ describe("sanitizeMermaidSourceForRender", () => {
       "}%%",
       "flowchart TD",
       'click node_safe "https://github.com/acme/demo/blob/main/src/a.ts"',
+      'click CORE "https://github.com/FastAPI/FastAPI/blob/master/fastapi/applications.py"',
       "click node_bad call alert()",
       'click node_bad "javascript:alert(1)"',
     ].join("\n");
@@ -21,6 +22,7 @@ describe("sanitizeMermaidSourceForRender", () => {
       [
         "flowchart TD",
         'click node_safe "https://github.com/acme/demo/blob/main/src/a.ts"',
+        'click CORE "https://github.com/FastAPI/FastAPI/blob/master/fastapi/applications.py"',
       ].join("\n"),
     );
   });

--- a/src/features/diagram/mermaid-security.ts
+++ b/src/features/diagram/mermaid-security.ts
@@ -1,5 +1,5 @@
 const safeGitHubClickDirective =
-  /^\s*click\s+node_[a-z][a-z0-9_]*\s+"https:\/\/github\.com\/[^"\s]+"\s*$/u;
+  /^\s*click\s+[a-z_][a-z0-9_-]*\s+"https:\/\/github\.com\/[^"\s]+"\s*$/iu;
 
 export function sanitizeMermaidSourceForRender(source: string): string {
   const lines: string[] = [];

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -39,6 +39,9 @@
     --neo-dot-active: 271 81% 55%;
     --neo-dot-inactive: 271 46% 78%;
     --neo-input-bg: 270 92% 89%;
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+    --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
   }
   .dark {
     --background: 264 22% 9%;
@@ -126,13 +129,8 @@
     color: #000 !important;
     box-shadow: 4px 4px 0 0 #000 !important;
     transition:
-      transform 0.2s ease,
-      background-color 0.2s ease;
-  }
-
-  .neo-button:hover:not(:disabled) {
-    background: hsl(var(--neo-button-hover)) !important;
-    transform: translate(-2px, -2px);
+      transform 160ms var(--ease-out),
+      background-color 160ms ease;
   }
 
   .neo-button-muted {
@@ -141,13 +139,8 @@
     color: #000 !important;
     box-shadow: 4px 4px 0 0 #000 !important;
     transition:
-      transform 0.2s ease,
-      background-color 0.2s ease;
-  }
-
-  .neo-button-muted:hover:not(:disabled) {
-    background: hsl(var(--neo-subtle)) !important;
-    transform: translate(-2px, -2px);
+      transform 160ms var(--ease-out),
+      background-color 160ms ease;
   }
 
   .browse-muted-button {
@@ -156,13 +149,12 @@
     color: #000 !important;
     box-shadow: 4px 4px 0 0 #000 !important;
     transition:
-      transform 0.2s ease,
-      background-color 0.2s ease;
+      transform 160ms var(--ease-out),
+      background-color 160ms ease;
   }
 
-  .browse-muted-button:hover:not(:disabled) {
-    background: hsl(var(--neo-panel)) !important;
-    transform: translate(-2px, -2px);
+  .neo-lift {
+    transition: transform 160ms var(--ease-out);
   }
 
   .neo-input {
@@ -184,11 +176,7 @@
 
   .neo-link {
     color: hsl(var(--neo-link));
-    transition: color 0.2s ease;
-  }
-
-  .neo-link:hover {
-    color: hsl(var(--neo-link-hover));
+    transition: color 160ms ease;
   }
 
   .dark .neo-panel,
@@ -211,8 +199,213 @@
     color: hsl(var(--foreground)) !important;
   }
 
-  .dark .browse-muted-button:hover:not(:disabled) {
-    background: hsl(var(--neo-panel)) !important;
+  @media (hover: hover) and (pointer: fine) {
+    .neo-button:hover:not(:disabled) {
+      background: hsl(var(--neo-button-hover)) !important;
+      transform: translate(-2px, -2px);
+    }
+
+    .neo-button-muted:hover:not(:disabled) {
+      background: hsl(var(--neo-subtle)) !important;
+      transform: translate(-2px, -2px);
+    }
+
+    .browse-muted-button:hover:not(:disabled) {
+      background: hsl(var(--neo-panel)) !important;
+      transform: translate(-2px, -2px);
+    }
+
+    .neo-link:hover {
+      color: hsl(var(--neo-link-hover));
+    }
+
+    .dark .browse-muted-button:hover:not(:disabled) {
+      background: hsl(var(--neo-panel)) !important;
+    }
+
+    .neo-lift:hover {
+      transform: translateY(-2px);
+    }
+  }
+
+  .neo-button:active:not(:disabled),
+  .neo-button-muted:active:not(:disabled),
+  .browse-muted-button:active:not(:disabled) {
+    transform: translate(1px, 1px) scale(0.97);
+    transition-duration: 120ms;
+  }
+
+  .neo-lift:active {
+    transform: translateY(1px) scale(0.97);
+  }
+
+  .mobile-menu-layer {
+    pointer-events: none;
+    visibility: hidden;
+    transition: visibility 0s linear 140ms;
+  }
+
+  .mobile-menu-layer[data-state="open"] {
+    pointer-events: auto;
+    visibility: visible;
+    transition-delay: 0s;
+  }
+
+  .mobile-menu-overlay {
+    opacity: 0;
+    transition: opacity 140ms var(--ease-out);
+  }
+
+  .mobile-menu-layer[data-state="open"] .mobile-menu-overlay {
+    opacity: 1;
+    transition-duration: 180ms;
+  }
+
+  .mobile-menu-panel {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.97);
+    transform-origin: top right;
+    transition:
+      opacity 140ms var(--ease-out),
+      transform 140ms var(--ease-out);
+  }
+
+  .mobile-menu-layer[data-state="open"] .mobile-menu-panel {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    transition-duration: 200ms;
+  }
+
+  .tooltip-content {
+    opacity: 0;
+    transform: scale(0.97);
+    transform-origin: var(--radix-tooltip-content-transform-origin);
+    transition:
+      opacity 100ms var(--ease-out),
+      transform 100ms var(--ease-out);
+  }
+
+  .tooltip-content[data-state="delayed-open"],
+  .tooltip-content[data-state="instant-open"] {
+    opacity: 1;
+    transform: scale(1);
+    transition-duration: 150ms;
+  }
+
+  .tooltip-content[data-state="instant-open"] {
+    transition-duration: 0ms;
+  }
+
+  .dialog-overlay[data-state="open"] {
+    animation: dialog-fade-in 180ms var(--ease-out) both;
+  }
+
+  .dialog-overlay[data-state="closed"] {
+    animation: dialog-fade-out 140ms var(--ease-out) both;
+  }
+
+  .dialog-content[data-state="open"] {
+    animation: dialog-content-in 220ms var(--ease-out) both;
+  }
+
+  .dialog-content[data-state="closed"] {
+    animation: dialog-content-out 160ms var(--ease-out) both;
+  }
+
+  .export-panel {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    transition:
+      opacity 180ms var(--ease-out),
+      transform 180ms var(--ease-out);
+  }
+
+  .status-message {
+    opacity: 1;
+    transform: translateY(0);
+    transition:
+      opacity 180ms var(--ease-out),
+      transform 180ms var(--ease-out);
+  }
+
+  .copy-button-content {
+    display: grid;
+    min-width: 12.75rem;
+  }
+
+  .copy-button-state {
+    grid-area: 1 / 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    transition:
+      opacity 160ms var(--ease-out),
+      transform 160ms var(--ease-out),
+      filter 160ms var(--ease-out);
+  }
+
+  .copy-button-state[data-active="false"] {
+    opacity: 0;
+    filter: blur(2px);
+    transform: translateY(2px);
+  }
+}
+
+@keyframes dialog-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialog-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes dialog-content-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes dialog-content-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+}
+
+@starting-style {
+  .tooltip-content[data-state="delayed-open"] {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+
+  .export-panel {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.99);
+  }
+
+  .status-message {
+    opacity: 0;
+    transform: translateY(-4px);
   }
 }
 
@@ -224,7 +417,58 @@
   cursor: pointer !important;
 }
 
-.star-reminder-toast [data-button]:hover,
-.star-reminder-toast button:hover {
-  background: hsl(var(--neo-button-hover)) !important;
+@media (hover: hover) and (pointer: fine) {
+  .star-reminder-toast [data-button]:hover,
+  .star-reminder-toast button:hover {
+    background: hsl(var(--neo-button-hover)) !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neo-button,
+  .neo-button-muted,
+  .browse-muted-button {
+    transition-property: background-color, color, opacity;
+  }
+
+  .neo-lift {
+    transition-property: opacity;
+  }
+
+  .neo-button:active:not(:disabled),
+  .neo-button-muted:active:not(:disabled),
+  .browse-muted-button:active:not(:disabled) {
+    opacity: 0.82;
+    transform: none;
+  }
+
+  .neo-lift:hover,
+  .neo-lift:active {
+    opacity: 0.82;
+    transform: none;
+  }
+
+  .dialog-content[data-state="open"] {
+    animation: dialog-fade-in 180ms var(--ease-out) both;
+  }
+
+  .dialog-content[data-state="closed"] {
+    animation: dialog-fade-out 120ms var(--ease-out) both;
+  }
+
+  .mobile-menu-panel,
+  .mobile-menu-layer[data-state="open"] .mobile-menu-panel {
+    transform: none;
+  }
+
+  .tooltip-content,
+  .tooltip-content[data-state="delayed-open"],
+  .tooltip-content[data-state="instant-open"],
+  .export-panel,
+  .status-message,
+  .copy-button-state,
+  .copy-button-state[data-active="false"] {
+    filter: none;
+    transform: none;
+  }
 }


### PR DESCRIPTION
## What changed

- Refined interactive motion across buttons, menus, dialogs, tooltips, loading states, copy feedback, and navigation.
- Restored diagram hover feedback only for genuinely clickable Mermaid nodes, including legacy example click identifiers.
- Added reduced-motion and pointer-capability safeguards so hover motion does not leak onto static nodes or touch devices.
- Added a deterministic Mermaid modernization utility with tests.
- Added operator scripts to generate, validate, back up, promote, and restore example diagram artifacts without storing legacy diagram bodies in source.
- Added the motion audit and implementation plans used for this polish pass.

## Why

The prior example artifacts used legacy Mermaid identifiers, which caused their click affordances to diverge from newly generated diagrams. A broad hover workaround then made static diagram elements animate too. This change restores the intended clickable-only behavior and brings the surrounding UI motion to a consistent, accessible standard.

## Impact

Clickable diagram nodes now lift subtly on hover while non-clickable nodes remain static. The five example repositories use newly generated structured diagrams in R2, with the old artifacts retained in a dedicated rollback snapshot.

## Validation

- React Doctor changed-scope scan: no issues
- `bun run check`
- `bun run test`: 36 files, 182 tests passed
- `bun run build`
- Browser rendering verified for all five promoted example diagrams
- Production diagram-preview hashes verified for all five examples
