### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
 OPENAI_API_KEY=
-# OPTIONAL: choose which provider to use for generation: openai | openrouter | atlas
+# OPTIONAL: choose which provider to use for generation: openai | openrouter | requesty | atlas
 AI_PROVIDER=openai
 # OPTIONAL: Atlas Cloud credentials/model when AI_PROVIDER=atlas
 ATLAS_API_KEY=
@@ -26,6 +26,12 @@ OPENROUTER_API_KEY=
 OPENROUTER_MODEL=openai/gpt-5.6-terra
 OPENROUTER_SITE_URL=http://localhost:3000
 OPENROUTER_APP_NAME=GitDiagram
+# OPTIONAL: Requesty credentials/model when AI_PROVIDER=requesty
+REQUESTY_API_KEY=
+REQUESTY_MODEL=openai/gpt-5.6-terra
+REQUESTY_BASE_URL=https://router.requesty.ai/v1
+REQUESTY_SITE_URL=http://localhost:3000
+REQUESTY_APP_NAME=GitDiagram
 NEXT_PUBLIC_POSTHOG_KEY=
 
 # OPTIONAL: providing one or more GitHub PATs increases GitHub API rate limits.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can also replace `hub` with `diagram` in a GitHub URL to open its diagram.
 - **Streaming generation:** see the explanation arrive while the graph is planned.
 - **Private repositories:** provide a GitHub token locally in the browser; private artifacts use a separate protected storage namespace.
 - **Export:** copy Mermaid source or download the rendered diagram as PNG.
-- **Provider choice:** OpenAI by default, with OpenRouter and Atlas Cloud available for self-hosted deployments.
+- **Provider choice:** OpenAI by default, with OpenRouter, Requesty, and Atlas Cloud available for self-hosted deployments.
 
 ## Stack
 
@@ -28,7 +28,7 @@ You can also replace `hub` with `diagram` in a GitHub URL to open its diagram.
 - **Generation API:** same-origin Next.js Route Handlers running on Vercel's Bun runtime
 - **Storage:** Cloudflare R2 for diagram artifacts
 - **Coordination:** Upstash Redis for quota accounting, cancellation, locks, and short-lived failure state
-- **AI:** OpenAI, OpenRouter, or Atlas Cloud through `AI_PROVIDER`
+- **AI:** OpenAI, OpenRouter, Requesty, or Atlas Cloud through `AI_PROVIDER`
 - **Analytics:** PostHog
 - **Deployment:** Vercel is the only live runtime; an offline Railway/Docker recipe is retained for disaster recovery
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -38,6 +38,7 @@ Choose one AI provider:
 
 - OpenAI: `AI_PROVIDER=openai` and `OPENAI_API_KEY`
 - OpenRouter: `AI_PROVIDER=openrouter` and `OPENROUTER_API_KEY`
+- Requesty: `AI_PROVIDER=requesty` and `REQUESTY_API_KEY`
 - Atlas Cloud: `AI_PROVIDER=atlas` and `ATLAS_API_KEY`
 
 Optional generation controls include:
@@ -49,6 +50,10 @@ Optional generation controls include:
 - `OPENROUTER_MODEL`
 - `OPENROUTER_SITE_URL`
 - `OPENROUTER_APP_NAME`
+- `REQUESTY_MODEL`
+- `REQUESTY_BASE_URL`
+- `REQUESTY_SITE_URL`
+- `REQUESTY_APP_NAME`
 - `ATLAS_MODEL`
 - `ATLAS_BASE_URL`
 
@@ -77,6 +82,16 @@ OPENROUTER_API_KEY=...
 OPENROUTER_MODEL=openai/gpt-5.6-terra
 OPENROUTER_SITE_URL=http://localhost:3000
 OPENROUTER_APP_NAME=GitDiagram
+```
+
+A Requesty example:
+
+```dotenv
+AI_PROVIDER=requesty
+REQUESTY_API_KEY=...
+REQUESTY_MODEL=openai/gpt-5.6-terra
+REQUESTY_SITE_URL=http://localhost:3000
+REQUESTY_APP_NAME=GitDiagram
 ```
 
 ## Run

--- a/src/server/generate/model-config.test.ts
+++ b/src/server/generate/model-config.test.ts
@@ -42,6 +42,18 @@ describe("getModel", () => {
     expect(getModel("openrouter")).toBe("openai/gpt-5.6-terra");
   });
 
+  it("uses GPT-5.6 Terra as the Requesty fallback", () => {
+    delete process.env.REQUESTY_MODEL;
+
+    expect(getModel("requesty")).toBe("openai/gpt-5.6-terra");
+  });
+
+  it("preserves an explicit Requesty model override", () => {
+    process.env.REQUESTY_MODEL = "anthropic/claude-sonnet-4-5";
+
+    expect(getModel("requesty")).toBe("anthropic/claude-sonnet-4-5");
+  });
+
   it("uses the Atlas model override when configured", () => {
     process.env.ATLAS_MODEL = "deepseek-ai/DeepSeek-V3-0324";
 

--- a/src/server/generate/model-config.ts
+++ b/src/server/generate/model-config.ts
@@ -1,10 +1,11 @@
-export type AIProvider = "atlas" | "openai" | "openrouter";
+export type AIProvider = "atlas" | "openai" | "openrouter" | "requesty";
 
 import { DEFAULT_ATLAS_MODEL } from "~/server/generate/atlas-models";
 
 const DEFAULT_PROVIDER: AIProvider = "openai";
 const DEFAULT_OPENAI_MODEL = "gpt-5.6-terra";
 const DEFAULT_OPENROUTER_MODEL = "openai/gpt-5.6-terra";
+const DEFAULT_REQUESTY_MODEL = "openai/gpt-5.6-terra";
 const GPT_56_MODEL_PATTERN =
   /^gpt-5\.6(?:-(?:sol|terra|luna))?(?:-\d{4}-\d{2}-\d{2})?$/i;
 
@@ -21,6 +22,9 @@ function normalizeProvider(value?: string): AIProvider {
   if (normalized === "openrouter") {
     return "openrouter";
   }
+  if (normalized === "requesty") {
+    return "requesty";
+  }
   return DEFAULT_PROVIDER;
 }
 
@@ -32,7 +36,13 @@ export function getProviderLabel(provider: AIProvider): string {
   if (provider === "atlas") {
     return "Atlas Cloud";
   }
-  return provider === "openrouter" ? "OpenRouter" : "OpenAI";
+  if (provider === "openrouter") {
+    return "OpenRouter";
+  }
+  if (provider === "requesty") {
+    return "Requesty";
+  }
+  return "OpenAI";
 }
 
 export function supportsExactInputTokenCount(provider: AIProvider): boolean {
@@ -62,6 +72,9 @@ export function getModel(provider = getProvider()): string {
   }
   if (provider === "openrouter") {
     return readEnvValue("OPENROUTER_MODEL") ?? DEFAULT_OPENROUTER_MODEL;
+  }
+  if (provider === "requesty") {
+    return readEnvValue("REQUESTY_MODEL") ?? DEFAULT_REQUESTY_MODEL;
   }
 
   return readEnvValue("OPENAI_MODEL") ?? DEFAULT_OPENAI_MODEL;

--- a/src/server/generate/openai.ts
+++ b/src/server/generate/openai.ts
@@ -24,6 +24,9 @@ function getEnvApiKey(provider: AIProvider): string | undefined {
   if (provider === "openrouter") {
     return process.env.OPENROUTER_API_KEY?.trim();
   }
+  if (provider === "requesty") {
+    return process.env.REQUESTY_API_KEY?.trim();
+  }
 
   return process.env.OPENAI_API_KEY?.trim();
 }
@@ -44,6 +47,22 @@ function getOpenRouterHeaders(): Record<string, string> {
   return headers;
 }
 
+function getRequestyHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const siteUrl = process.env.REQUESTY_SITE_URL?.trim();
+  const appName = process.env.REQUESTY_APP_NAME?.trim() || "GitDiagram";
+
+  if (siteUrl) {
+    headers["HTTP-Referer"] = siteUrl;
+  }
+
+  if (appName) {
+    headers["X-Title"] = appName;
+  }
+
+  return headers;
+}
+
 function createClient(provider: AIProvider, apiKey: string): OpenAI {
   if (provider === "atlas") {
     return new OpenAI({
@@ -58,6 +77,16 @@ function createClient(provider: AIProvider, apiKey: string): OpenAI {
       apiKey,
       baseURL: "https://openrouter.ai/api/v1",
       defaultHeaders: getOpenRouterHeaders(),
+      maxRetries: AI_MAX_RETRIES,
+      timeout: AI_REQUEST_TIMEOUT_MS,
+    });
+  }
+  if (provider === "requesty") {
+    return new OpenAI({
+      apiKey,
+      baseURL:
+        process.env.REQUESTY_BASE_URL?.trim() || "https://router.requesty.ai/v1",
+      defaultHeaders: getRequestyHeaders(),
       maxRetries: AI_MAX_RETRIES,
       timeout: AI_REQUEST_TIMEOUT_MS,
     });
@@ -98,7 +127,9 @@ function resolveApiKey(provider: AIProvider, overrideApiKey?: string): string {
         ? "ATLAS_API_KEY"
         : provider === "openrouter"
           ? "OPENROUTER_API_KEY"
-          : "OPENAI_API_KEY";
+          : provider === "requesty"
+            ? "REQUESTY_API_KEY"
+            : "OPENAI_API_KEY";
     throw new Error(
       `Missing ${getProviderLabel(provider)} API key. Set ${envVarName} or provide api_key in request.`,
     );
@@ -553,9 +584,9 @@ export async function generateStructuredOutput<T>({
       error instanceof Error
         ? error.message
         : "Structured output request failed.";
-    if (provider === "openrouter") {
+    if (provider === "openrouter" || provider === "requesty") {
       throw new Error(
-        `OpenRouter model does not support the required structured graph output: ${message}`,
+        `${getProviderLabel(provider)} model does not support the required structured graph output: ${message}`,
       );
     }
     throw error;


### PR DESCRIPTION
## Add Requesty as an OpenAI-compatible provider

This adds [Requesty](https://requesty.ai) as a third AI provider next to OpenAI and OpenRouter, mirroring the existing OpenRouter integration as closely as possible.

Requesty is an OpenAI compatible LLM router that exposes hundreds of models behind a single endpoint using `provider/model` naming (the same convention as OpenRouter), so it slots into the existing generation pipeline directly. It is opt in only: nothing changes unless you set `AI_PROVIDER=requesty`, and it is never auto selected or used as a fallback.

### Changes

Rebased on current main. Upstream removed the Atlas Cloud provider in the meantime, so this version no longer touches any Atlas wiring and the README and docs now list only OpenAI, OpenRouter and Requesty. The structured output rejection handling in `openai.ts` now covers Requesty as well as OpenRouter, and the model config tests gained a case checking that Requesty is only recognized when selected explicitly.

* `src/server/generate/model-config.ts`: add `requesty` to the `AIProvider` union, `normalizeProvider`, `getProviderLabel`, and the model resolver (`REQUESTY_MODEL`, defaulting to `openai/gpt-5.6-terra`, the same model the OpenAI and OpenRouter defaults use).
* `src/server/generate/openai.ts`: `REQUESTY_API_KEY` lookup, `getRequestyHeaders()` (optional `HTTP-Referer` and `X-Title`, which Requesty supports), a `createClient` case with base URL `https://router.requesty.ai/v1` (overridable via `REQUESTY_BASE_URL`), the matching env var name in the missing key error, and the structured output rejection path now uses the provider label so the error message is correct for both routers.
* `src/server/generate/model-config.test.ts`: tests for explicit Requesty selection, the Requesty default model, and the `REQUESTY_MODEL` override.
* `.env.example`, `README.md`, `docs/dev-setup.md`: document the provider and its env vars (`REQUESTY_API_KEY`, `REQUESTY_MODEL`, `REQUESTY_BASE_URL`, `REQUESTY_SITE_URL`, `REQUESTY_APP_NAME`).

### Testing

* `bun run typecheck` (`tsc --noEmit`): clean.
* `vitest run` on the touched test files: passing.
* eslint on the changed files: clean.
* Verified live against the Requesty endpoint with the same base URL and Bearer auth the provider uses: `openai/gpt-5.6-terra` is present in `GET /v1/models` and a chat completion on it returned HTTP 200.

Config: get a key at https://app.requesty.ai/api-keys, browse models at https://app.requesty.ai/model-library, docs at https://docs.requesty.ai.

Disclosure: I work at Requesty. Happy to adjust anything to match project conventions.
