### PR TITLE
Enable native mobile diagram pinch zoom

### DIFF
--- a/src/components/mermaid-diagram.test.tsx
+++ b/src/components/mermaid-diagram.test.tsx
@@ -132,7 +132,7 @@ describe("MermaidChart", () => {
     expect(config?.themeCSS).toContain("prefers-reduced-motion: reduce");
   });
 
-  it("keeps vertical touch scrolling enabled in read-only mode", () => {
+  it("allows vertical scrolling and native pinch zoom in read-only mode", () => {
     const { container } = render(
       <MermaidChart chart="flowchart TD\nA-->B" zoomingEnabled={false} />,
     );
@@ -140,6 +140,7 @@ describe("MermaidChart", () => {
     const interactionLayer = container.querySelector(".touch-pan-y");
 
     expect(interactionLayer).toBeInTheDocument();
+    expect(interactionLayer).toHaveClass("touch-pinch-zoom");
     expect(container.querySelector(".touch-none")).not.toBeInTheDocument();
   });
 

--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -561,7 +561,9 @@ const MermaidChart = ({
         ref={interactionLayerRef}
         className={cn(
           "relative h-full",
-          zoomingEnabled ? "touch-none" : "touch-pan-y",
+          zoomingEnabled
+            ? "touch-none"
+            : "touch-pan-y touch-pinch-zoom",
           (zoomingEnabled || fitToContainer) && "overflow-hidden",
           zoomingEnabled &&
             "rounded-xl border border-black/12 bg-white/30 select-none dark:border-white/12 dark:bg-white/[0.03] [&_*]:select-none",


### PR DESCRIPTION
## What changed

- allow native pinch zoom on read-only mobile diagrams
- preserve vertical page scrolling
- keep the opt-in desktop pan/zoom viewer unchanged
- add regression coverage for the combined touch-action behavior

## Root cause

The read-only diagram layer used `touch-action: pan-y`, which allowed vertical scrolling but prevented mobile browsers from recognizing pinch zoom gestures over the diagram.

## Validation

- `bun run check`
- `bun run test` (219 tests)
- `bun run build`
- mobile viewport verification at 390x844 with zoom mode disabled
- computed touch action: `pan-y pinch-zoom`
- no browser console errors
