### PR TITLE
Enable two-axis mobile diagram panning

### DIFF
--- a/src/components/mermaid-diagram.test.tsx
+++ b/src/components/mermaid-diagram.test.tsx
@@ -132,7 +132,7 @@ describe("MermaidChart", () => {
     expect(config?.themeCSS).toContain("prefers-reduced-motion: reduce");
   });
 
-  it("allows vertical scrolling and native pinch zoom in read-only mode", () => {
+  it("allows two-axis panning and native pinch zoom in read-only mode", () => {
     const { container } = render(
       <MermaidChart chart="flowchart TD\nA-->B" zoomingEnabled={false} />,
     );
@@ -140,6 +140,7 @@ describe("MermaidChart", () => {
     const interactionLayer = container.querySelector(".touch-pan-y");
 
     expect(interactionLayer).toBeInTheDocument();
+    expect(interactionLayer).toHaveClass("touch-pan-x");
     expect(interactionLayer).toHaveClass("touch-pinch-zoom");
     expect(container.querySelector(".touch-none")).not.toBeInTheDocument();
   });

--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -563,7 +563,7 @@ const MermaidChart = ({
           "relative h-full",
           zoomingEnabled
             ? "touch-none"
-            : "touch-pan-y touch-pinch-zoom",
+            : "touch-pan-x touch-pan-y touch-pinch-zoom",
           (zoomingEnabled || fitToContainer) && "overflow-hidden",
           zoomingEnabled &&
             "rounded-xl border border-black/12 bg-white/30 select-none dark:border-white/12 dark:bg-white/[0.03] [&_*]:select-none",


### PR DESCRIPTION
## What changed

- allow native one-finger panning in both horizontal and vertical directions on mobile diagrams
- preserve native pinch zoom and normal page scrolling
- keep the opt-in desktop pan/zoom viewer unchanged
- extend regression coverage for the complete touch-action contract

## Root cause

The read-only diagram layer allowed `pan-y pinch-zoom`, so iOS could zoom and move vertically but horizontal movement remained blocked while zoomed in.

## Validation

- `bun run check`
- `bun run test` (219 tests)
- `bun run build`
- React Doctor regression scan (90/100, unchanged warnings)
- local 390x844 mobile viewport verification with zoom mode disabled
- computed touch action resolves to full browser `manipulation` mode
- no browser console errors
