### PR TITLE
Remove the purple URL input focus ring

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -144,11 +144,6 @@
     outline: none !important;
   }
 
-  .neo-input:focus-visible {
-    outline: 3px solid hsl(var(--neo-link)) !important;
-    outline-offset: 3px;
-  }
-
   .dark .neo-input {
     background: hsl(var(--neo-input-bg)) !important;
   }


### PR DESCRIPTION
## What changed

- removed the purple outer focus outline from the shared neo-brutalist URL input style
- preserved the input's existing black border and hard shadow

## Why

The landing-page repository URL field added a separate purple halo whenever the field was focused, which clashed with its black border treatment.

## Impact

The URL field now keeps the same clean black frame while users click, type, or select its contents.

## Validation

- `bun run check`
- `NODE_OPTIONS=--no-experimental-webstorage bun run test` (282 tests)
- `bun run format:check`
- `bun run build`
- `bunx knip --reporter compact`
- `bun audit`
- `bun run perf:budget`
- production-build browser check: focused outline is `none`, black border/shadow remain, console is clean
