### PR TITLE
Tighten the mobile repo card layout

### DIFF
--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -39,7 +39,7 @@ export function CopyButton({ onClick }: CopyButtonProps) {
           type="button"
           onClick={handleClick}
           aria-label={copied ? "Mermaid code copied" : "Copy Mermaid.js code"}
-          className="neo-button p-4 px-4 text-base sm:p-6 sm:px-6 sm:text-lg"
+          className="neo-button h-11 w-full px-3 text-sm sm:h-10 sm:w-auto sm:p-6 sm:px-6 sm:text-lg"
         >
           <span className="copy-button-content" aria-hidden="true">
             <span className="copy-button-state" data-active={!copied}>

--- a/src/components/export-dropdown.tsx
+++ b/src/components/export-dropdown.tsx
@@ -21,8 +21,8 @@ export function ExportDropdown({
   onExportImage,
 }: ExportDropdownProps) {
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+    <div className="space-y-3 sm:space-y-4">
+      <div className="flex flex-col gap-2.5 sm:flex-row sm:gap-4">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -30,7 +30,7 @@ export function ExportDropdown({
                 event.preventDefault();
                 onExportImage();
               }}
-              className="neo-button p-4 px-4 text-base sm:p-6 sm:px-6 sm:text-lg"
+              className="neo-button h-11 w-full px-3 text-sm sm:h-10 sm:w-auto sm:p-6 sm:px-6 sm:text-lg"
             >
               <ImageIcon className="h-6 w-6" />
               <span className="text-sm">Download PNG</span>
@@ -45,14 +45,14 @@ export function ExportDropdown({
 
       {lastGenerated ? (
         <div className="flex items-center">
-          <span className="text-sm text-gray-700 dark:text-neutral-300">
+          <span className="text-xs text-gray-700 sm:text-sm dark:text-neutral-300">
             Last generated: {lastGenerated.toLocaleString()}
           </span>
         </div>
       ) : null}
       {actualCost ? (
         <div className="flex items-center">
-          <span className="text-sm text-gray-700 dark:text-neutral-300">
+          <span className="text-xs text-gray-700 sm:text-sm dark:text-neutral-300">
             Actual cost: {actualCost}
           </span>
         </div>

--- a/src/components/main-card.tsx
+++ b/src/components/main-card.tsx
@@ -104,10 +104,10 @@ export default function MainCard({
         ) : null}
 
         {!isHome && (
-          <div className="space-y-4">
+          <div className="space-y-3 sm:space-y-4">
             {!loading && (
               <>
-                <div className="flex flex-col items-center gap-4 sm:flex-row sm:gap-4">
+                <div className="grid grid-cols-2 gap-3 sm:flex sm:items-center sm:gap-4">
                   {onRegenerate && (
                     <button
                       type="button"
@@ -117,7 +117,7 @@ export default function MainCard({
                           ? "Regeneration is disabled for example repositories."
                           : undefined
                       }
-                      className={`flex items-center justify-between gap-2 rounded-md border-[3px] border-black px-4 py-2 font-medium text-black transition-[background-color,transform] duration-150 ease-[var(--ease-out)] active:scale-[0.97] motion-reduce:active:scale-100 motion-reduce:active:opacity-80 sm:max-w-[250px] dark:text-black ${
+                      className={`flex min-h-11 w-full items-center justify-center gap-2 rounded-md border-[3px] border-black px-2 py-2 text-sm leading-tight font-semibold text-black transition-[background-color,transform] duration-150 ease-[var(--ease-out)] active:scale-[0.97] motion-reduce:active:scale-100 motion-reduce:active:opacity-80 sm:min-h-0 sm:w-auto sm:max-w-[250px] sm:justify-between sm:px-4 sm:text-base sm:font-medium dark:text-black ${
                         isExampleRepoSelected
                           ? "cursor-not-allowed bg-purple-200 opacity-70 dark:bg-[#251b3a] dark:text-[hsl(var(--foreground))]"
                           : "bg-purple-300 hover:bg-purple-400 dark:border-[#2d1d4e] dark:bg-[hsl(var(--neo-subtle-muted))] dark:hover:bg-[hsl(var(--neo-subtle))]"
@@ -129,40 +129,42 @@ export default function MainCard({
                         onRegenerate();
                       }}
                     >
-                      Regenerate Diagram
+                      <span className="sm:hidden">Regenerate</span>
+                      <span className="hidden sm:inline">
+                        Regenerate Diagram
+                      </span>
                     </button>
                   )}
                   {hasDiagram && onCopy && onExportImage && (
-                    <div className="flex flex-col items-center justify-center gap-2">
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleDropdownToggle("export");
-                        }}
-                        aria-expanded={activeDropdown === "export"}
-                        className={`flex cursor-pointer items-center justify-between gap-2 rounded-md border-[3px] border-black px-4 py-2 font-medium text-black transition-[background-color,transform] duration-150 ease-[var(--ease-out)] active:scale-[0.97] motion-reduce:active:scale-100 motion-reduce:active:opacity-80 sm:max-w-[250px] dark:text-black ${
-                          activeDropdown === "export"
-                            ? "bg-purple-400 dark:border-[#2d1d4e] dark:bg-[hsl(var(--neo-button))]"
-                            : "bg-purple-300 hover:bg-purple-400 dark:border-[#2d1d4e] dark:bg-[hsl(var(--neo-subtle-muted))] dark:hover:bg-[hsl(var(--neo-button-hover))]"
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handleDropdownToggle("export");
+                      }}
+                      aria-expanded={activeDropdown === "export"}
+                      className={`flex min-h-11 w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border-[3px] border-black px-2 py-2 text-sm leading-tight font-semibold text-black transition-[background-color,transform] duration-150 ease-[var(--ease-out)] active:scale-[0.97] motion-reduce:active:scale-100 motion-reduce:active:opacity-80 sm:min-h-0 sm:w-auto sm:max-w-[250px] sm:justify-between sm:gap-2 sm:px-4 sm:text-base sm:font-medium dark:text-black ${
+                        activeDropdown === "export"
+                          ? "bg-purple-400 dark:border-[#2d1d4e] dark:bg-[hsl(var(--neo-button))]"
+                          : "bg-purple-300 hover:bg-purple-400 dark:border-[#2d1d4e] dark:bg-[hsl(var(--neo-subtle-muted))] dark:hover:bg-[hsl(var(--neo-button-hover))]"
+                      }`}
+                    >
+                      <span className="sm:hidden">Export</span>
+                      <span className="hidden sm:inline">Export Diagram</span>
+                      <ChevronDown
+                        size={20}
+                        aria-hidden="true"
+                        className={`size-4 transition-transform duration-150 ease-[var(--ease-in-out)] motion-reduce:rotate-0 sm:size-5 ${
+                          activeDropdown === "export" ? "rotate-180" : ""
                         }`}
-                      >
-                        <span>Export Diagram</span>
-                        <ChevronDown
-                          size={20}
-                          aria-hidden="true"
-                          className={`transition-transform duration-150 ease-[var(--ease-in-out)] motion-reduce:rotate-0 ${
-                            activeDropdown === "export" ? "rotate-180" : ""
-                          }`}
-                        />
-                      </button>
-                    </div>
+                      />
+                    </button>
                   )}
                   {hasDiagram && (
-                    <>
+                    <div className="col-span-2 flex min-h-11 w-full items-center justify-between gap-4 border-t-2 border-black/15 pt-3 sm:min-h-0 sm:w-auto sm:border-0 sm:pt-0 dark:border-white/15">
                       <label
                         htmlFor="zoom-toggle"
-                        className="font-medium text-black dark:text-neutral-100"
+                        className="text-sm font-semibold text-black sm:text-base sm:font-medium dark:text-neutral-100"
                       >
                         Enable Zoom
                       </label>
@@ -171,7 +173,7 @@ export default function MainCard({
                         checked={zoomingEnabled}
                         onCheckedChange={onZoomToggle}
                       />
-                    </>
+                    </div>
                   )}
                 </div>
 


### PR DESCRIPTION
## What changed

- place Regenerate and Export in an equal two-column action row on mobile
- group the zoom label and switch into one aligned horizontal row
- keep export tools full-width with 44px touch targets and tighter metadata spacing
- preserve the existing desktop action layout and labels

## Why

The repo-page card stacked each secondary action at a different width, then put the zoom label and switch on separate rows. That made the mobile card tall, uneven, and harder to scan.

## Impact

At 390px, the closed card is reduced from 376px to 278px and the expanded export card from 516px to 416px. Controls remain comfortable to tap and continue to fit at 320px without overflow.

## Validation

- `bun run check`
- `NODE_OPTIONS=--no-experimental-webstorage bun run test` (282 tests)
- `bun run format:check`
- `bun run build`
- React Doctor changed-scope scan: 100/100
- `bunx knip --reporter compact`
- `bun audit`
- `bun run perf:budget`
- production-build browser checks at 320px, 390px, desktop, light mode, dark mode, collapsed and expanded states
