### PR TITLE
fix: secure repository access and make browse indexing durable

### DIFF
--- a/scripts/migrate-browse-index.ts
+++ b/scripts/migrate-browse-index.ts
@@ -1,4 +1,4 @@
-import { migrateBrowseIndexToCompressedV2 } from "../src/server/storage/browse-diagrams";
+import { migrateBrowseIndexToAtomicV3 } from "../src/server/storage/browse-diagrams";
 
-const entryCount = await migrateBrowseIndexToCompressedV2();
-console.log(`Compressed browse index is ready (${entryCount} entries).`);
+const entryCount = await migrateBrowseIndexToAtomicV3();
+console.log(`Atomic browse index is ready (${entryCount} entries).`);

--- a/src/app/api/generate/cost/route.test.ts
+++ b/src/app/api/generate/cost/route.test.ts
@@ -115,15 +115,18 @@ describe("POST /api/generate/cost", () => {
   it("rejects a cross-origin caller before touching GitHub", async () => {
     // Estimation runs the same GitHub ingestion as a real generation, so an
     // open endpoint drains the server's shared API budget.
-    const crossOrigin = new Request("https://gitdiagram.com/api/generate/cost", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Origin: "https://evil.example",
-        "Sec-Fetch-Site": "cross-site",
+    const crossOrigin = new Request(
+      "https://gitdiagram.com/api/generate/cost",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://evil.example",
+          "Sec-Fetch-Site": "cross-site",
+        },
+        body: JSON.stringify({ username: "openai", repo: "openai-node" }),
       },
-      body: JSON.stringify({ username: "openai", repo: "openai-node" }),
-    });
+    );
 
     const response = await POST(crossOrigin);
 

--- a/src/app/api/generate/stream/route.test.ts
+++ b/src/app/api/generate/stream/route.test.ts
@@ -558,6 +558,57 @@ describe("POST /api/generate/stream", () => {
     });
   });
 
+  it("keeps the final cost labeled as an estimate when stage usage is missing", async () => {
+    mockEstimate(100);
+    mocks.admitQuota.mockResolvedValue({
+      admitted: true,
+      reservation: {
+        reservationId: "reservation-1",
+        quotaBucket: "daily",
+        quotaDateUtc: "2026-07-13",
+        quotaResetAt: "2026-07-14T00:00:00.000Z",
+        reservedTokens: 20_000,
+      },
+    });
+    mocks.streamCompletion.mockResolvedValue({
+      stream: (async function* () {
+        yield "<explanation>Usage-free explanation.</explanation>";
+      })(),
+      usagePromise: Promise.resolve(null),
+    });
+    const graph = {
+      groups: [],
+      nodes: [
+        {
+          id: "entrypoint",
+          label: "Entry point",
+          type: "TypeScript module",
+          description: null,
+          groupId: null,
+          path: "src/index.ts",
+          shape: "box",
+        },
+      ],
+      edges: [],
+    };
+    mocks.generateStructuredOutput.mockResolvedValue({
+      output: graph,
+      rawText: JSON.stringify(graph),
+      usage: { inputTokens: 80, outputTokens: 20, totalTokens: 100 },
+    });
+
+    const response = await POST(request());
+    const terminal = readSseEvents(await response.text()).find(
+      (event) => event.status === "complete",
+    );
+
+    expect(terminal?.cost_summary).toMatchObject({
+      kind: "estimate",
+      approximate: true,
+      note: expect.stringContaining("remains a conservative estimate"),
+    });
+  });
+
   it("coalesces explanation deltas without changing their bytes or order", async () => {
     mockEstimate(100);
     mocks.admitQuota.mockResolvedValue({

--- a/src/app/api/generate/stream/route.ts
+++ b/src/app/api/generate/stream/route.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { after } from "next/server";
 
 import type { GenerationTokenUsage } from "~/features/diagram/cost";
@@ -25,7 +24,6 @@ import {
 import { normalizeGenerationError } from "~/server/generate/errors";
 import { createFinalGenerationCostSummary } from "~/server/generate/final-cost";
 import {
-  registerActiveGeneration,
   startGenerationCancellationPolling,
   unregisterActiveGeneration,
 } from "~/server/generate/cancellation";
@@ -84,14 +82,7 @@ import {
   createCostSummary,
   sumGenerationUsage,
 } from "~/server/generate/pricing";
-import {
-  consumeGenerationRateLimit,
-  getGenerationRateLimitMessage,
-  refundGenerationRateLimit,
-} from "~/server/generate/rate-limit";
-import { parseGenerateRequest } from "~/server/generate/types";
-import { getClientIp } from "~/server/http/client-ip";
-import { resolveRequestCredentials } from "~/server/http/request-credentials";
+import { admitGenerationRequest } from "~/server/generate/request-admission";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -115,124 +106,26 @@ function throwIfAborted(signal: AbortSignal) {
 }
 
 export async function POST(request: Request) {
-  const parsed = await parseGenerateRequest(request);
-  if (!parsed.success) {
-    return new Response(
-      JSON.stringify({
-        ok: false,
-        error: parsed.error,
-        error_code: parsed.errorCode,
-      }),
-      {
-        status: parsed.status,
-        headers: {
-          "Content-Type": "application/json",
-          "Cache-Control": "no-store",
-          "X-Content-Type-Options": "nosniff",
-        },
-      },
-    );
+  const admission = await admitGenerationRequest(request);
+  if (!admission.admitted) {
+    return admission.response;
   }
-
   const {
     username,
     repo,
-    session_id: requestedSessionId,
-    cancel_token: requestedCancelToken,
-  } = parsed.data;
-  const { apiKey, githubPat } = await resolveRequestCredentials(request, {
-    apiKey: parsed.data.api_key,
-    githubPat: parsed.data.github_pat,
-  });
-
-  // Generations billed to the server's own key are the ones that can drain the
-  // shared daily budget, so they are the ones worth throttling per caller.
-  const rateLimitedClientIp = apiKey?.trim() ? null : getClientIp(request);
-  // Returned on the early-reject paths below, which cost the caller a slot
-  // without ever reaching a billable model call.
-  const refundRateLimit = () =>
-    refundGenerationRateLimit({ clientIp: rateLimitedClientIp });
-  if (!apiKey?.trim()) {
-    const rateLimit = await consumeGenerationRateLimit({
-      clientIp: rateLimitedClientIp,
-    });
-    if (!rateLimit.allowed) {
-      return Response.json(
-        {
-          ok: false,
-          error: getGenerationRateLimitMessage(rateLimit.retryAfterSeconds),
-          error_code: "RATE_LIMITED",
-        },
-        {
-          status: 429,
-          headers: {
-            "Cache-Control": "no-store",
-            "X-Content-Type-Options": "nosniff",
-            "Retry-After": String(rateLimit.retryAfterSeconds),
-          },
-        },
-      );
-    }
-  }
-
-  const sessionId = requestedSessionId ?? randomUUID();
-  let cancellationRegistered = false;
-  if (requestedSessionId && requestedCancelToken) {
-    try {
-      cancellationRegistered = await registerActiveGeneration(
-        sessionId,
-        requestedCancelToken,
-      );
-    } catch {
-      console.error(
-        JSON.stringify({
-          event: "generate.cancellation.registration_failed",
-          session_id: sessionId,
-          error: "Cancellation registration is temporarily unavailable.",
-        }),
-      );
-      await refundRateLimit();
-      return Response.json(
-        {
-          ok: false,
-          error: "Generation is temporarily unavailable. Please retry.",
-          error_code: "CANCELLATION_UNAVAILABLE",
-        },
-        {
-          status: 503,
-          headers: {
-            "Cache-Control": "no-store",
-            "X-Content-Type-Options": "nosniff",
-          },
-        },
-      );
-    }
-
-    if (!cancellationRegistered) {
-      await refundRateLimit();
-      return Response.json(
-        {
-          ok: false,
-          error: "Generation session already exists. Please retry.",
-          error_code: "SESSION_CONFLICT",
-        },
-        {
-          status: 409,
-          headers: {
-            "Cache-Control": "no-store",
-            "X-Content-Type-Options": "nosniff",
-          },
-        },
-      );
-    }
-  }
+    apiKey,
+    githubPat,
+    sessionId,
+    cancelToken,
+    cancellationRegistered,
+  } = admission.value;
   const generationAbortController = new AbortController();
   const deadlineSignal = AbortSignal.timeout(GENERATION_DEADLINE_MS);
   const postResponseTasks: Array<() => Promise<void>> = [];
-  if (cancellationRegistered && requestedCancelToken) {
+  if (cancellationRegistered && cancelToken) {
     postResponseTasks.push(async () => {
       try {
-        await unregisterActiveGeneration(sessionId, requestedCancelToken);
+        await unregisterActiveGeneration(sessionId, cancelToken);
       } catch {
         console.warn(
           JSON.stringify({

--- a/src/app/api/generate/stream/route.ts
+++ b/src/app/api/generate/stream/route.ts
@@ -23,6 +23,7 @@ import {
   type GenerationEstimateResult,
 } from "~/server/generate/cost-estimate";
 import { normalizeGenerationError } from "~/server/generate/errors";
+import { createFinalGenerationCostSummary } from "~/server/generate/final-cost";
 import {
   registerActiveGeneration,
   startGenerationCancellationPolling,
@@ -767,18 +768,13 @@ export async function POST(request: Request) {
             diagram,
           });
 
-          const finalCost = accounting.hasCompleteMeasuredUsage
-            ? createCostSummary({
-                kind: "actual",
-                model,
-                usage: sumGenerationUsage(...accounting.actualUsages),
-                approximate: false,
-              })
-            : {
-                ...estimate.costSummary,
-                kind: "actual" as const,
-                note: "Some stage usage was unavailable, so the final cost remains approximate.",
-              };
+          const finalCost = createFinalGenerationCostSummary({
+            model,
+            estimate,
+            actualUsages: accounting.actualUsages,
+            hasCompleteMeasuredUsage: accounting.hasCompleteMeasuredUsage,
+            graphAttemptCount: audit.graphAttempts.length,
+          });
           throwIfAborted(generationAbortController.signal);
           audit = withFinalCost(audit, finalCost);
           audit = withSuccess(

--- a/src/server/generate/complimentary-gate.ts
+++ b/src/server/generate/complimentary-gate.ts
@@ -9,12 +9,12 @@ import type { AIProvider } from "~/server/generate/model-config";
 import {
   EXPLANATION_MAX_OUTPUT_TOKENS,
   GRAPH_MAX_OUTPUT_TOKENS,
+  GRAPH_RETRY_INPUT_BUFFER_TOKENS,
 } from "~/server/generate/pricing";
 
 const DEFAULT_DAILY_LIMIT_TOKENS = 10_000_000;
 const DEFAULT_MODEL_FAMILY = "gpt-5.6-terra";
 const COMPLIMENTARY_QUOTA_BUCKET = "openai-complimentary-small-models";
-const RETRY_INPUT_BUFFER_TOKENS = 2_000;
 const QUOTA_FINALIZATION_ATTEMPTS = 2;
 const DEFAULT_DENIAL_MESSAGE =
   "GitDiagram's free daily OpenAI capacity is used up for now. I'm a solo student engineer running this free and open source, so please try again after 00:00 UTC or use your own OpenAI API key.";
@@ -172,7 +172,7 @@ export function buildComplimentaryStageTokenBound(
     estimate.graphRepairStaticInputTokens +
     EXPLANATION_MAX_OUTPUT_TOKENS +
     GRAPH_MAX_OUTPUT_TOKENS +
-    RETRY_INPUT_BUFFER_TOKENS +
+    GRAPH_RETRY_INPUT_BUFFER_TOKENS +
     GRAPH_MAX_OUTPUT_TOKENS
   );
 }

--- a/src/server/generate/final-cost.test.ts
+++ b/src/server/generate/final-cost.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import type { GenerationEstimateResult } from "./cost-estimate";
+import { createFinalGenerationCostSummary } from "./final-cost";
+import {
+  EXPLANATION_MAX_OUTPUT_TOKENS,
+  GRAPH_MAX_OUTPUT_TOKENS,
+  GRAPH_RETRY_INPUT_BUFFER_TOKENS,
+} from "./generation-policy";
+
+function createEstimate(): GenerationEstimateResult {
+  return {
+    costSummary: {
+      kind: "estimate",
+      approximate: true,
+      amountUsd: 0.01,
+      display: "$0.010 USD",
+      pricingModel: "gpt-5.6-terra",
+      usage: {
+        inputTokens: 1_000,
+        outputTokens: 500,
+        totalTokens: 1_500,
+      },
+    },
+    estimatedInputTokens: 1_000,
+    estimatedOutputTokens: 500,
+    pricingModel: "gpt-5.6-terra",
+    pricing: {
+      inputPerMillionUsd: 2.5,
+      outputPerMillionUsd: 15,
+    },
+    explanationInputTokens: 400,
+    graphStaticInputTokens: 300,
+    graphRepairStaticInputTokens: 800,
+  };
+}
+
+describe("createFinalGenerationCostSummary", () => {
+  it("reports complete provider usage as actual", () => {
+    const result = createFinalGenerationCostSummary({
+      model: "gpt-5.6-terra",
+      estimate: createEstimate(),
+      actualUsages: [
+        { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        { inputTokens: 200, outputTokens: 75, totalTokens: 275 },
+      ],
+      hasCompleteMeasuredUsage: true,
+      graphAttemptCount: 1,
+    });
+
+    expect(result).toMatchObject({
+      kind: "actual",
+      approximate: false,
+      usage: {
+        inputTokens: 300,
+        outputTokens: 125,
+        totalTokens: 425,
+      },
+    });
+  });
+
+  it("keeps incomplete usage labeled as a conservative multi-attempt estimate", () => {
+    const result = createFinalGenerationCostSummary({
+      model: "gpt-5.6-terra",
+      estimate: createEstimate(),
+      actualUsages: [],
+      hasCompleteMeasuredUsage: false,
+      graphAttemptCount: 3,
+    });
+    const retryInputTokens =
+      800 +
+      EXPLANATION_MAX_OUTPUT_TOKENS +
+      GRAPH_MAX_OUTPUT_TOKENS +
+      GRAPH_RETRY_INPUT_BUFFER_TOKENS;
+
+    expect(result).toMatchObject({
+      kind: "estimate",
+      approximate: true,
+      usage: {
+        inputTokens: 1_000 + retryInputTokens * 2,
+        outputTokens: 500 + GRAPH_MAX_OUTPUT_TOKENS * 2,
+      },
+    });
+    expect(result.note).toContain("3 graph-planning attempts");
+  });
+
+  it("uses the initial request estimate as a safe retry fallback", () => {
+    const estimate = createEstimate();
+    estimate.graphRepairStaticInputTokens = null;
+
+    const result = createFinalGenerationCostSummary({
+      model: "gpt-5.6-terra",
+      estimate,
+      actualUsages: [],
+      hasCompleteMeasuredUsage: false,
+      graphAttemptCount: 2,
+    });
+
+    expect(result.usage.inputTokens).toBe(
+      1_000 + 1_000 + GRAPH_MAX_OUTPUT_TOKENS + GRAPH_RETRY_INPUT_BUFFER_TOKENS,
+    );
+    expect(result.kind).toBe("estimate");
+  });
+});

--- a/src/server/generate/final-cost.ts
+++ b/src/server/generate/final-cost.ts
@@ -1,0 +1,55 @@
+import type {
+  GenerationCostSummary,
+  GenerationTokenUsage,
+} from "~/features/diagram/cost";
+import type { GenerationEstimateResult } from "./cost-estimate";
+import {
+  EXPLANATION_MAX_OUTPUT_TOKENS,
+  GRAPH_MAX_OUTPUT_TOKENS,
+  GRAPH_RETRY_INPUT_BUFFER_TOKENS,
+} from "./generation-policy";
+import { createCostSummary, sumGenerationUsage } from "./pricing";
+
+export function createFinalGenerationCostSummary(params: {
+  model: string;
+  estimate: GenerationEstimateResult;
+  actualUsages: GenerationTokenUsage[];
+  hasCompleteMeasuredUsage: boolean;
+  graphAttemptCount: number;
+}): GenerationCostSummary {
+  if (params.hasCompleteMeasuredUsage) {
+    return createCostSummary({
+      kind: "actual",
+      model: params.model,
+      usage: sumGenerationUsage(...params.actualUsages),
+      approximate: false,
+    });
+  }
+
+  const graphAttemptCount = Math.max(params.graphAttemptCount, 1);
+  const retryCount = Math.max(graphAttemptCount - 1, 0);
+  const baseUsage = params.estimate.costSummary.usage;
+  const retryInputTokens =
+    params.estimate.graphRepairStaticInputTokens !== null
+      ? params.estimate.graphRepairStaticInputTokens +
+        EXPLANATION_MAX_OUTPUT_TOKENS +
+        GRAPH_MAX_OUTPUT_TOKENS +
+        GRAPH_RETRY_INPUT_BUFFER_TOKENS
+      : baseUsage.inputTokens +
+        GRAPH_MAX_OUTPUT_TOKENS +
+        GRAPH_RETRY_INPUT_BUFFER_TOKENS;
+  const usage: GenerationTokenUsage = {
+    inputTokens: baseUsage.inputTokens + retryInputTokens * retryCount,
+    outputTokens: baseUsage.outputTokens + GRAPH_MAX_OUTPUT_TOKENS * retryCount,
+    totalTokens: 0,
+  };
+  usage.totalTokens = usage.inputTokens + usage.outputTokens;
+
+  return createCostSummary({
+    kind: "estimate",
+    model: params.model,
+    usage,
+    approximate: true,
+    note: `Provider usage was unavailable for at least one stage, so this remains a conservative estimate for ${graphAttemptCount} graph-planning attempt${graphAttemptCount === 1 ? "" : "s"}.`,
+  });
+}

--- a/src/server/generate/generation-policy.ts
+++ b/src/server/generate/generation-policy.ts
@@ -6,3 +6,4 @@ export const GRAPH_TEXT_VERBOSITY = "low" as const;
 
 export const EXPLANATION_MAX_OUTPUT_TOKENS = 6_000;
 export const GRAPH_MAX_OUTPUT_TOKENS = 6_000;
+export const GRAPH_RETRY_INPUT_BUFFER_TOKENS = 2_000;

--- a/src/server/generate/github.test.ts
+++ b/src/server/generate/github.test.ts
@@ -295,7 +295,7 @@ describe("getGithubData repository input bounds", () => {
     expect(treeRequests).toBe(2);
   });
 
-  it("never stores or conditionally reuses private repository trees", async () => {
+  it("rejects private repository access without caller credentials before reading contents", async () => {
     const fetchMock = vi.fn(
       async (input: string | URL | Request, init?: RequestInit) => {
         const url = String(input);
@@ -324,8 +324,55 @@ describe("getGithubData repository input bounds", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await getGithubData("acme", "demo");
-    await getGithubData("acme", "demo");
-    expect(fetchMock).toHaveBeenCalledTimes(6);
+    await expect(getGithubData("acme", "demo")).rejects.toThrow(
+      "A GitHub token is required to analyze a private repository.",
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/demo",
+      expect.any(Object),
+    );
+  });
+
+  it("reads private repository contents only with caller credentials", async () => {
+    const fetchMock = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/repos/acme/demo")) {
+          return jsonResponse({ default_branch: "main", private: true });
+        }
+        if (url.includes("/git/trees/main?recursive=1")) {
+          expect(new Headers(init?.headers).has("if-none-match")).toBe(false);
+          return new Response(
+            JSON.stringify({
+              truncated: false,
+              tree: [{ path: "src/private.ts", type: "blob" }],
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.endsWith("/repos/acme/demo/readme")) {
+          return jsonResponse({
+            size: 9,
+            content: Buffer.from("# Private").toString("base64"),
+            encoding: "base64",
+          });
+        }
+        throw new Error(`Unexpected GitHub URL: ${url}`);
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      getGithubData("acme", "demo", "github_pat_caller"),
+    ).resolves.toMatchObject({
+      fileTree: "src/private.ts",
+      readme: "# Private",
+      isPrivate: true,
+    });
+    expect(getGitHubApiHeaders).toHaveBeenCalledWith({
+      githubPat: "github_pat_caller",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/server/generate/github.ts
+++ b/src/server/generate/github.ts
@@ -35,6 +35,8 @@ export type RepositoryPathType = "blob" | "tree";
 
 export const REPOSITORY_TOO_LARGE_ERROR =
   "Repository is too large (>195k tokens) for analysis. Try a smaller repo.";
+export const PRIVATE_REPOSITORY_AUTH_REQUIRED_ERROR =
+  "A GitHub token is required to analyze a private repository.";
 export const MAX_INCLUDED_FILE_TREE_CHARACTERS = 780_000;
 export const MAX_README_BYTES = 750_000;
 export const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
@@ -357,27 +359,35 @@ export async function getGithubData(
   githubPat?: string,
   signal?: AbortSignal,
 ): Promise<GithubData> {
+  const hasCallerGithubPat = Boolean(githubPat?.trim());
   const headers = await getGitHubApiHeaders({ githubPat });
-  const readmeResultPromise = getReadme(username, repo, headers, signal).then(
-    (value) => ({ ok: true as const, value }),
-    (error: unknown) => ({ ok: false as const, error }),
-  );
   const { defaultBranch, isPrivate, stargazerCount } = await getRepoMetadata(
     username,
     repo,
     headers,
     signal,
   );
+
+  // GitHub App installation tokens and the server PAT pool may be able to read
+  // private repositories. They improve public API rate limits, but they must
+  // never become authorization for an anonymous caller.
+  if (isPrivate && !hasCallerGithubPat) {
+    throw new Error(PRIVATE_REPOSITORY_AUTH_REQUIRED_ERROR);
+  }
+
   const [tree, readmeResult] = await Promise.all([
     getFileTree(
       username,
       repo,
       defaultBranch,
       headers,
-      !githubPat?.trim() && !isPrivate,
+      !hasCallerGithubPat && !isPrivate,
       signal,
     ),
-    readmeResultPromise,
+    getReadme(username, repo, headers, signal).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    ),
   ]);
   // A repository without a README is still perfectly diagrammable from its file
   // tree, so only a genuine fetch failure should abort the run.

--- a/src/server/generate/github.ts
+++ b/src/server/generate/github.ts
@@ -35,7 +35,7 @@ export type RepositoryPathType = "blob" | "tree";
 
 export const REPOSITORY_TOO_LARGE_ERROR =
   "Repository is too large (>195k tokens) for analysis. Try a smaller repo.";
-export const PRIVATE_REPOSITORY_AUTH_REQUIRED_ERROR =
+const PRIVATE_REPOSITORY_AUTH_REQUIRED_ERROR =
   "A GitHub token is required to analyze a private repository.";
 export const MAX_INCLUDED_FILE_TREE_CHARACTERS = 780_000;
 export const MAX_README_BYTES = 750_000;

--- a/src/server/generate/pricing.ts
+++ b/src/server/generate/pricing.ts
@@ -5,11 +5,13 @@ import type {
 import {
   EXPLANATION_MAX_OUTPUT_TOKENS,
   GRAPH_MAX_OUTPUT_TOKENS,
+  GRAPH_RETRY_INPUT_BUFFER_TOKENS,
 } from "~/server/generate/generation-policy";
 
 export {
   EXPLANATION_MAX_OUTPUT_TOKENS,
   GRAPH_MAX_OUTPUT_TOKENS,
+  GRAPH_RETRY_INPUT_BUFFER_TOKENS,
 } from "~/server/generate/generation-policy";
 
 export interface ModelPricing {

--- a/src/server/generate/pricing.ts
+++ b/src/server/generate/pricing.ts
@@ -5,7 +5,6 @@ import type {
 import {
   EXPLANATION_MAX_OUTPUT_TOKENS,
   GRAPH_MAX_OUTPUT_TOKENS,
-  GRAPH_RETRY_INPUT_BUFFER_TOKENS,
 } from "~/server/generate/generation-policy";
 
 export {

--- a/src/server/generate/rate-limit.ts
+++ b/src/server/generate/rate-limit.ts
@@ -3,7 +3,7 @@ import { upstashEval } from "~/server/storage/upstash";
 const DEFAULT_MAX_GENERATIONS = 8;
 const DEFAULT_WINDOW_SECONDS = 60 * 60;
 
-export const GENERATION_RATE_LIMIT_SCRIPT = `
+const GENERATION_RATE_LIMIT_SCRIPT = `
 local key = KEYS[1]
 local limit = tonumber(ARGV[1])
 local window = tonumber(ARGV[2])
@@ -48,7 +48,7 @@ export function getGenerationRateLimitWindowSeconds(): number {
   );
 }
 
-export const GENERATION_RATE_LIMIT_REFUND_SCRIPT = `
+const GENERATION_RATE_LIMIT_REFUND_SCRIPT = `
 local key = KEYS[1]
 local count = tonumber(redis.call("GET", key))
 if not count or count <= 0 then

--- a/src/server/generate/request-admission.test.ts
+++ b/src/server/generate/request-admission.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  consumeRateLimit: vi.fn(),
+  getClientIp: vi.fn(),
+  refundRateLimit: vi.fn(),
+  registerActiveGeneration: vi.fn(),
+  resolveRequestCredentials: vi.fn(),
+}));
+
+vi.mock("./cancellation", () => ({
+  registerActiveGeneration: mocks.registerActiveGeneration,
+}));
+vi.mock("./rate-limit", () => ({
+  consumeGenerationRateLimit: mocks.consumeRateLimit,
+  getGenerationRateLimitMessage: vi.fn(
+    (seconds: number) => `Retry in ${seconds} seconds.`,
+  ),
+  refundGenerationRateLimit: mocks.refundRateLimit,
+}));
+vi.mock("~/server/http/client-ip", () => ({
+  getClientIp: mocks.getClientIp,
+}));
+vi.mock("~/server/http/request-credentials", () => ({
+  resolveRequestCredentials: mocks.resolveRequestCredentials,
+}));
+
+import { admitGenerationRequest } from "./request-admission";
+
+function request(body: Record<string, unknown> = {}) {
+  return new Request("https://gitdiagram.com/api/generate/stream", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: "openai", repo: "openai-node", ...body }),
+  });
+}
+
+describe("admitGenerationRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.consumeRateLimit.mockResolvedValue({
+      allowed: true,
+      retryAfterSeconds: 0,
+    });
+    mocks.getClientIp.mockReturnValue("203.0.113.10");
+    mocks.refundRateLimit.mockResolvedValue(undefined);
+    mocks.registerActiveGeneration.mockResolvedValue(true);
+    mocks.resolveRequestCredentials.mockImplementation(
+      async (
+        _request: Request,
+        explicit: { apiKey?: string; githubPat?: string },
+      ) => explicit,
+    );
+  });
+
+  it("admits a complimentary caller with normalized request context", async () => {
+    const result = await admitGenerationRequest(request());
+
+    expect(result).toMatchObject({
+      admitted: true,
+      value: {
+        username: "openai",
+        repo: "openai-node",
+        cancellationRegistered: false,
+      },
+    });
+    if (result.admitted) {
+      expect(result.value.sessionId).toEqual(expect.any(String));
+    }
+    expect(mocks.consumeRateLimit).toHaveBeenCalledWith({
+      clientIp: "203.0.113.10",
+    });
+  });
+
+  it("does not rate-limit a caller using their own model key", async () => {
+    mocks.resolveRequestCredentials.mockResolvedValue({ apiKey: "sk-user" });
+
+    const result = await admitGenerationRequest(request());
+
+    expect(result.admitted).toBe(true);
+    expect(mocks.consumeRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("returns the limiter response before registering a session", async () => {
+    mocks.consumeRateLimit.mockResolvedValue({
+      allowed: false,
+      retryAfterSeconds: 900,
+    });
+
+    const result = await admitGenerationRequest(request());
+
+    expect(result.admitted).toBe(false);
+    if (!result.admitted) {
+      expect(result.response.status).toBe(429);
+      expect(result.response.headers.get("retry-after")).toBe("900");
+      await expect(result.response.json()).resolves.toMatchObject({
+        error_code: "RATE_LIMITED",
+      });
+    }
+    expect(mocks.registerActiveGeneration).not.toHaveBeenCalled();
+  });
+
+  it("refunds the limiter when cancellation registration is unavailable", async () => {
+    mocks.registerActiveGeneration.mockRejectedValue(new Error("Redis down"));
+
+    const result = await admitGenerationRequest(
+      request({
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+        cancel_token: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      }),
+    );
+
+    expect(result.admitted).toBe(false);
+    if (!result.admitted) {
+      expect(result.response.status).toBe(503);
+    }
+    expect(mocks.refundRateLimit).toHaveBeenCalledWith({
+      clientIp: "203.0.113.10",
+    });
+  });
+
+  it("refunds the limiter when the requested session already exists", async () => {
+    mocks.registerActiveGeneration.mockResolvedValue(false);
+
+    const result = await admitGenerationRequest(
+      request({
+        session_id: "550e8400-e29b-41d4-a716-446655440000",
+        cancel_token: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      }),
+    );
+
+    expect(result.admitted).toBe(false);
+    if (!result.admitted) {
+      expect(result.response.status).toBe(409);
+      await expect(result.response.json()).resolves.toMatchObject({
+        error_code: "SESSION_CONFLICT",
+      });
+    }
+    expect(mocks.refundRateLimit).toHaveBeenCalledWith({
+      clientIp: "203.0.113.10",
+    });
+  });
+
+  it("rejects invalid transport input before resolving credentials", async () => {
+    const invalidRequest = new Request(
+      "https://gitdiagram.com/api/generate/stream",
+      {
+        method: "POST",
+        body: "{}",
+      },
+    );
+
+    const result = await admitGenerationRequest(invalidRequest);
+
+    expect(result.admitted).toBe(false);
+    if (!result.admitted) {
+      expect(result.response.status).toBe(415);
+    }
+    expect(mocks.resolveRequestCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/generate/request-admission.ts
+++ b/src/server/generate/request-admission.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+
+import { registerActiveGeneration } from "./cancellation";
+import {
+  consumeGenerationRateLimit,
+  getGenerationRateLimitMessage,
+  refundGenerationRateLimit,
+} from "./rate-limit";
+import { parseGenerateRequest } from "./types";
+import { getClientIp } from "~/server/http/client-ip";
+import { resolveRequestCredentials } from "~/server/http/request-credentials";
+
+interface AdmittedGenerationRequest {
+  username: string;
+  repo: string;
+  apiKey?: string;
+  githubPat?: string;
+  sessionId: string;
+  cancelToken?: string;
+  cancellationRegistered: boolean;
+}
+
+type GenerationRequestAdmission =
+  | { admitted: true; value: AdmittedGenerationRequest }
+  | { admitted: false; response: Response };
+
+function jsonError(
+  body: { error: string; errorCode: string },
+  init: { status: number; retryAfterSeconds?: number },
+): Response {
+  return Response.json(
+    {
+      ok: false,
+      error: body.error,
+      error_code: body.errorCode,
+    },
+    {
+      status: init.status,
+      headers: {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+        ...(init.retryAfterSeconds
+          ? { "Retry-After": String(init.retryAfterSeconds) }
+          : {}),
+      },
+    },
+  );
+}
+
+export async function admitGenerationRequest(
+  request: Request,
+): Promise<GenerationRequestAdmission> {
+  const parsed = await parseGenerateRequest(request);
+  if (!parsed.success) {
+    return {
+      admitted: false,
+      response: jsonError(
+        {
+          error: parsed.error,
+          errorCode: parsed.errorCode,
+        },
+        { status: parsed.status },
+      ),
+    };
+  }
+
+  const {
+    username,
+    repo,
+    session_id: requestedSessionId,
+    cancel_token: cancelToken,
+  } = parsed.data;
+  const { apiKey, githubPat } = await resolveRequestCredentials(request, {
+    apiKey: parsed.data.api_key,
+    githubPat: parsed.data.github_pat,
+  });
+  const rateLimitedClientIp = apiKey?.trim() ? null : getClientIp(request);
+  const refundRateLimit = () =>
+    refundGenerationRateLimit({ clientIp: rateLimitedClientIp });
+
+  if (!apiKey?.trim()) {
+    const rateLimit = await consumeGenerationRateLimit({
+      clientIp: rateLimitedClientIp,
+    });
+    if (!rateLimit.allowed) {
+      return {
+        admitted: false,
+        response: jsonError(
+          {
+            error: getGenerationRateLimitMessage(rateLimit.retryAfterSeconds),
+            errorCode: "RATE_LIMITED",
+          },
+          {
+            status: 429,
+            retryAfterSeconds: rateLimit.retryAfterSeconds,
+          },
+        ),
+      };
+    }
+  }
+
+  const sessionId = requestedSessionId ?? randomUUID();
+  let cancellationRegistered = false;
+  if (requestedSessionId && cancelToken) {
+    try {
+      cancellationRegistered = await registerActiveGeneration(
+        sessionId,
+        cancelToken,
+      );
+    } catch {
+      console.error(
+        JSON.stringify({
+          event: "generate.cancellation.registration_failed",
+          session_id: sessionId,
+          error: "Cancellation registration is temporarily unavailable.",
+        }),
+      );
+      await refundRateLimit();
+      return {
+        admitted: false,
+        response: jsonError(
+          {
+            error: "Generation is temporarily unavailable. Please retry.",
+            errorCode: "CANCELLATION_UNAVAILABLE",
+          },
+          { status: 503 },
+        ),
+      };
+    }
+
+    if (!cancellationRegistered) {
+      await refundRateLimit();
+      return {
+        admitted: false,
+        response: jsonError(
+          {
+            error: "Generation session already exists. Please retry.",
+            errorCode: "SESSION_CONFLICT",
+          },
+          { status: 409 },
+        ),
+      };
+    }
+  }
+
+  return {
+    admitted: true,
+    value: {
+      username,
+      repo,
+      apiKey,
+      githubPat,
+      sessionId,
+      cancelToken,
+      cancellationRegistered,
+    },
+  };
+}

--- a/src/server/og/repo-metadata.test.ts
+++ b/src/server/og/repo-metadata.test.ts
@@ -56,6 +56,27 @@ describe("getRepoSocialMetadata", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it("does not expose metadata for repositories visible only to server credentials", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          default_branch: "main",
+          private: true,
+          language: "TypeScript",
+          stargazers_count: 42,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(getRepoSocialMetadata("owner", "private")).resolves.toEqual({
+      defaultBranch: null,
+      isPrivate: null,
+      language: null,
+      stargazerCount: null,
+    });
+  });
+
   it("records upstream failures as warnings while preserving the fallback card", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(null, { status: 503 }),

--- a/src/server/og/repo-metadata.ts
+++ b/src/server/og/repo-metadata.ts
@@ -52,6 +52,9 @@ export async function getRepoSocialMetadata(
     }
 
     const data = (await response.json()) as RepoMetadataResponse;
+    if (data.private === true) {
+      return EMPTY_REPO_SOCIAL_METADATA;
+    }
 
     return {
       defaultBranch:

--- a/src/server/storage/browse-diagrams.test.ts
+++ b/src/server/storage/browse-diagrams.test.ts
@@ -6,36 +6,94 @@ vi.mock("~/server/storage/distributed-lock", () => ({
   ),
 }));
 
-const { getGzipJsonObject, getJsonObject, putGzipJsonObject } = vi.hoisted(
-  () => ({
-    getGzipJsonObject: vi.fn(),
-    getJsonObject: vi.fn(),
-    putGzipJsonObject: vi.fn(),
-  }),
-);
-
-vi.mock("~/server/storage/r2", () => ({
-  getGzipJsonObject,
-  getJsonObject,
-  putGzipJsonObject,
+const storageMocks = vi.hoisted(() => ({
+  deleteObject: vi.fn(),
+  getGzipJsonObject: vi.fn(),
+  getJsonObject: vi.fn(),
+  putGzipJsonObject: vi.fn(),
 }));
+
+vi.mock("~/server/storage/r2", () => storageMocks);
 
 import {
   BrowseIndexNotFoundError,
   getBrowsePage,
-  migrateBrowseIndexToCompressedV2,
+  migrateBrowseIndexToAtomicV3,
+  readRecentBrowseIndex,
   upsertBrowseIndexEntry,
+  type BrowseIndexEntry,
 } from "~/server/storage/browse-diagrams";
+
+const BUCKET = "test-public-bucket";
+const LEGACY_KEY = "public/v1/_meta/browse-index.json";
+const V2_INDEX_KEY = "public/v2/_meta/browse-index.json.gz";
+const V3_MANIFEST_KEY = "public/v3/_meta/browse-index-manifest.json.gz";
+const V3_SNAPSHOT_PREFIX = "public/v3/_meta/browse-index-snapshot-";
+
+let gzipObjects: Map<string, unknown>;
+let jsonObjects: Map<string, unknown>;
+
+function seedAtomicIndex(
+  entries: BrowseIndexEntry[],
+  generation = "existing-generation",
+  retainedGenerations = [generation],
+) {
+  const snapshotKey = `${V3_SNAPSHOT_PREFIX}${generation}.json.gz`;
+  for (const retainedGeneration of retainedGenerations) {
+    gzipObjects.set(`${V3_SNAPSHOT_PREFIX}${retainedGeneration}.json.gz`, {
+      version: 3,
+      generation: retainedGeneration,
+      updatedAt: "2026-03-29T12:00:00.000Z",
+      entries,
+    });
+  }
+  gzipObjects.set(V3_MANIFEST_KEY, {
+    version: 3,
+    generation,
+    updatedAt: "2026-03-29T12:00:00.000Z",
+    snapshotKey,
+    retainedSnapshotKeys: retainedGenerations.map(
+      (retainedGeneration) =>
+        `${V3_SNAPSHOT_PREFIX}${retainedGeneration}.json.gz`,
+    ),
+    total: entries.length,
+    entries: entries.slice(0, 2_000),
+  });
+  return snapshotKey;
+}
 
 describe("browse diagram storage", () => {
   beforeEach(() => {
-    process.env.R2_PUBLIC_BUCKET = "test-public-bucket";
+    process.env.R2_PUBLIC_BUCKET = BUCKET;
     vi.clearAllMocks();
-    getGzipJsonObject.mockResolvedValue(null);
+    gzipObjects = new Map();
+    jsonObjects = new Map();
+    storageMocks.getGzipJsonObject.mockImplementation(
+      async (_bucket: string, key: string) => {
+        const value = gzipObjects.get(key);
+        return value === undefined ? null : structuredClone(value);
+      },
+    );
+    storageMocks.getJsonObject.mockImplementation(
+      async (_bucket: string, key: string) => {
+        const value = jsonObjects.get(key);
+        return value === undefined ? null : structuredClone(value);
+      },
+    );
+    storageMocks.putGzipJsonObject.mockImplementation(
+      async (_bucket: string, key: string, payload: unknown) => {
+        gzipObjects.set(key, structuredClone(payload));
+      },
+    );
+    storageMocks.deleteObject.mockImplementation(
+      async (_bucket: string, key: string) => {
+        gzipObjects.delete(key);
+      },
+    );
   });
 
-  it("upserts a new repo and preserves browse metadata", async () => {
-    getJsonObject.mockResolvedValue({
+  it("publishes a full snapshot before atomically committing its recent manifest", async () => {
+    jsonObjects.set(LEGACY_KEY, {
       version: 1,
       updatedAt: "2026-03-27T12:00:00.000Z",
       entries: [
@@ -55,65 +113,86 @@ describe("browse diagram storage", () => {
       stargazerCount: 42,
     });
 
-    expect(entries).toEqual([
-      {
-        username: "acme",
-        repo: "demo",
-        lastSuccessfulAt: "2026-03-28T12:00:00.000Z",
-        stargazerCount: 42,
-      },
-      {
-        username: "older",
-        repo: "repo",
-        lastSuccessfulAt: "2026-03-27T12:00:00.000Z",
-        stargazerCount: 5,
-      },
+    expect(entries.map(({ username, repo }) => `${username}/${repo}`)).toEqual([
+      "acme/demo",
+      "older/repo",
     ]);
-    expect(putGzipJsonObject).toHaveBeenCalledWith(
-      "test-public-bucket",
-      "public/v2/_meta/browse-index.json.gz",
+    const snapshotCall = storageMocks.putGzipJsonObject.mock.calls[0];
+    const manifestCall = storageMocks.putGzipJsonObject.mock.calls[1];
+    expect(snapshotCall?.[0]).toBe(BUCKET);
+    expect(snapshotCall?.[1]).toMatch(
+      /^public\/v3\/_meta\/browse-index-snapshot-.+\.json\.gz$/,
+    );
+    expect(snapshotCall?.[2]).toMatchObject({ version: 3, entries });
+    expect(manifestCall).toEqual([
+      BUCKET,
+      V3_MANIFEST_KEY,
       expect.objectContaining({
-        version: 2,
+        version: 3,
+        snapshotKey: snapshotCall?.[1],
+        total: 2,
         entries,
       }),
-    );
+    ]);
+    expect(
+      storageMocks.putGzipJsonObject.mock.invocationCallOrder[0],
+    ).toBeLessThan(storageMocks.putGzipJsonObject.mock.invocationCallOrder[1]!);
   });
 
-  it("prefers the compressed manifest without reading the legacy object", async () => {
-    getGzipJsonObject.mockResolvedValue({
-      version: 1,
-      updatedAt: "2026-03-29T12:00:00.000Z",
-      entries: [
-        {
-          username: "Vercel",
-          repo: "Next.js",
-          lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
-          stargazerCount: 130000,
-        },
-      ],
-    });
+  it("reads the committed snapshot without consulting legacy objects", async () => {
+    seedAtomicIndex([
+      {
+        username: "vercel",
+        repo: "next.js",
+        lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
+        stargazerCount: 130000,
+      },
+    ]);
 
     const result = await getBrowsePage({});
 
     expect(result.items[0]).toEqual(
       expect.objectContaining({ username: "vercel", repo: "next.js" }),
     );
-    expect(getJsonObject).not.toHaveBeenCalled();
+    expect(storageMocks.getJsonObject).not.toHaveBeenCalled();
+    expect(
+      storageMocks.getGzipJsonObject.mock.calls.some(
+        (call) => call[1] === V2_INDEX_KEY,
+      ),
+    ).toBe(false);
   });
 
-  it("does not rewrite the manifest for a stale repository update", async () => {
-    getGzipJsonObject.mockResolvedValue({
-      version: 1,
-      updatedAt: "2026-03-29T12:00:00.000Z",
-      entries: [
-        {
-          username: "acme",
-          repo: "demo",
-          lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
-          stargazerCount: 42,
-        },
-      ],
+  it("serves the recent projection directly from the atomic manifest", async () => {
+    const entries = [
+      {
+        username: "acme",
+        repo: "demo",
+        lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
+        stargazerCount: 42,
+      },
+    ];
+    seedAtomicIndex(entries);
+
+    await expect(readRecentBrowseIndex()).resolves.toEqual({
+      total: 1,
+      entries,
     });
+    expect(storageMocks.getGzipJsonObject).toHaveBeenCalledOnce();
+    expect(storageMocks.getGzipJsonObject).toHaveBeenCalledWith(
+      BUCKET,
+      V3_MANIFEST_KEY,
+    );
+  });
+
+  it("does not rewrite a committed snapshot for a stale repository update", async () => {
+    seedAtomicIndex([
+      {
+        username: "acme",
+        repo: "demo",
+        lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
+        stargazerCount: 42,
+      },
+    ]);
 
     const entries = await upsertBrowseIndexEntry({
       username: "acme",
@@ -123,11 +202,80 @@ describe("browse diagram storage", () => {
     });
 
     expect(entries[0]?.stargazerCount).toBe(42);
-    expect(putGzipJsonObject).not.toHaveBeenCalled();
+    expect(storageMocks.putGzipJsonObject).not.toHaveBeenCalled();
+    expect(storageMocks.deleteObject).not.toHaveBeenCalled();
   });
 
-  it("falls back to the legacy manifest during the storage migration", async () => {
-    getJsonObject.mockResolvedValue({
+  it("retries a failed manifest commit using the same staged snapshot", async () => {
+    const previousSnapshotKey = seedAtomicIndex([
+      {
+        username: "older",
+        repo: "repo",
+        lastSuccessfulAt: "2026-03-27T12:00:00.000Z",
+        stargazerCount: 5,
+      },
+    ]);
+    let manifestAttempts = 0;
+    storageMocks.putGzipJsonObject.mockImplementation(
+      async (_bucket: string, key: string, payload: unknown) => {
+        if (key === V3_MANIFEST_KEY && manifestAttempts++ === 0) {
+          throw new Error("transient manifest failure");
+        }
+        gzipObjects.set(key, structuredClone(payload));
+      },
+    );
+
+    await expect(
+      upsertBrowseIndexEntry({
+        username: "acme",
+        repo: "demo",
+        lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
+        stargazerCount: 42,
+      }),
+    ).resolves.toHaveLength(2);
+
+    const snapshotKeys = storageMocks.putGzipJsonObject.mock.calls
+      .map((call) => call[1] as string)
+      .filter((key) => key.startsWith(V3_SNAPSHOT_PREFIX));
+    expect(new Set(snapshotKeys).size).toBe(1);
+    expect(manifestAttempts).toBe(2);
+    expect(storageMocks.deleteObject).not.toHaveBeenCalled();
+    expect(gzipObjects.get(V3_MANIFEST_KEY)).toMatchObject({
+      retainedSnapshotKeys: expect.arrayContaining([previousSnapshotKey]),
+    });
+  });
+
+  it("keeps the committed index when cleanup of the previous snapshot fails", async () => {
+    seedAtomicIndex(
+      [
+        {
+          username: "older",
+          repo: "repo",
+          lastSuccessfulAt: "2026-03-27T12:00:00.000Z",
+          stargazerCount: 5,
+        },
+      ],
+      "generation-0",
+      Array.from({ length: 8 }, (_, index) => `generation-${index}`),
+    );
+    storageMocks.deleteObject.mockRejectedValue(new Error("cleanup failed"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(
+      upsertBrowseIndexEntry({
+        username: "acme",
+        repo: "demo",
+        lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
+        stargazerCount: 42,
+      }),
+    ).resolves.toHaveLength(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("browse.index.snapshot_cleanup_failed"),
+    );
+  });
+
+  it("falls back to the legacy manifest during migration", async () => {
+    jsonObjects.set(LEGACY_KEY, {
       version: 1,
       updatedAt: "2026-03-29T12:00:00.000Z",
       entries: [
@@ -143,14 +291,11 @@ describe("browse diagram storage", () => {
     const result = await getBrowsePage({});
 
     expect(result.items).toHaveLength(1);
-    expect(getJsonObject).toHaveBeenCalledWith(
-      "test-public-bucket",
-      "public/v1/_meta/browse-index.json",
-    );
+    expect(storageMocks.getJsonObject).toHaveBeenCalledWith(BUCKET, LEGACY_KEY);
   });
 
-  it("seeds the compressed manifest under the browse-index lock", async () => {
-    getJsonObject.mockResolvedValue({
+  it("migrates a legacy index to an atomic snapshot and manifest", async () => {
+    jsonObjects.set(LEGACY_KEY, {
       version: 1,
       updatedAt: "2026-03-29T12:00:00.000Z",
       entries: [
@@ -163,46 +308,31 @@ describe("browse diagram storage", () => {
       ],
     });
 
-    await expect(migrateBrowseIndexToCompressedV2()).resolves.toBe(1);
-    expect(putGzipJsonObject).toHaveBeenCalledWith(
-      "test-public-bucket",
-      "public/v2/_meta/browse-index.json.gz",
-      expect.objectContaining({
-        version: 2,
-        entries: [expect.objectContaining({ username: "acme", repo: "demo" })],
-      }),
-    );
+    await expect(migrateBrowseIndexToAtomicV3()).resolves.toBe(1);
+    expect(gzipObjects.get(V3_MANIFEST_KEY)).toMatchObject({
+      version: 3,
+      total: 1,
+      entries: [expect.objectContaining({ username: "acme", repo: "demo" })],
+    });
   });
 
-  it("does not rewrite an already-canonical compressed manifest", async () => {
-    const entries = [
+  it("does not rewrite an already-atomic index during migration", async () => {
+    seedAtomicIndex([
       {
         username: "acme",
         repo: "demo",
         lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
         stargazerCount: 42,
       },
-    ];
-    getGzipJsonObject
-      .mockResolvedValueOnce({
-        version: 2,
-        updatedAt: "2026-03-29T12:00:00.000Z",
-        entries,
-      })
-      .mockResolvedValueOnce({
-        version: 1,
-        updatedAt: "2026-03-29T12:00:00.000Z",
-        total: 1,
-        entries,
-      });
+    ]);
 
-    await expect(migrateBrowseIndexToCompressedV2()).resolves.toBe(1);
-    expect(getJsonObject).not.toHaveBeenCalled();
-    expect(putGzipJsonObject).not.toHaveBeenCalled();
+    await expect(migrateBrowseIndexToAtomicV3()).resolves.toBe(1);
+    expect(storageMocks.putGzipJsonObject).not.toHaveBeenCalled();
+    expect(storageMocks.deleteObject).not.toHaveBeenCalled();
   });
 
   it("supports recent and star sorting, search, filtering, and pagination", async () => {
-    getJsonObject.mockResolvedValue({
+    jsonObjects.set(LEGACY_KEY, {
       version: 1,
       updatedAt: "2026-03-29T12:00:00.000Z",
       entries: [
@@ -247,9 +377,7 @@ describe("browse diagram storage", () => {
     expect(filteredResult.page).toBe(1);
   });
 
-  it("fails cleanly when the browse index manifest is missing", async () => {
-    getJsonObject.mockResolvedValue(null);
-
+  it("fails cleanly when every browse index location is missing", async () => {
     await expect(
       getBrowsePage({
         sort: "recent_desc",

--- a/src/server/storage/browse-diagrams.test.ts
+++ b/src/server/storage/browse-diagrams.test.ts
@@ -6,6 +6,14 @@ vi.mock("~/server/storage/distributed-lock", () => ({
   ),
 }));
 
+const pendingMocks = vi.hoisted(() => ({
+  acknowledgePendingBrowseIndexEntries: vi.fn(),
+  enqueuePendingBrowseIndexEntry: vi.fn(),
+  readPendingBrowseIndexEntries: vi.fn(),
+}));
+
+vi.mock("~/server/storage/browse-index-pending", () => pendingMocks);
+
 const storageMocks = vi.hoisted(() => ({
   deleteObject: vi.fn(),
   getGzipJsonObject: vi.fn(),
@@ -32,6 +40,11 @@ const V3_SNAPSHOT_PREFIX = "public/v3/_meta/browse-index-snapshot-";
 
 let gzipObjects: Map<string, unknown>;
 let jsonObjects: Map<string, unknown>;
+let pendingEntries: Array<{
+  field: string;
+  serialized: string;
+  entry: BrowseIndexEntry;
+}>;
 
 function seedAtomicIndex(
   entries: BrowseIndexEntry[],
@@ -68,6 +81,38 @@ describe("browse diagram storage", () => {
     vi.clearAllMocks();
     gzipObjects = new Map();
     jsonObjects = new Map();
+    pendingEntries = [];
+    pendingMocks.enqueuePendingBrowseIndexEntry.mockImplementation(
+      async (entry: BrowseIndexEntry) => {
+        const field = `${entry.username}/${entry.repo}`;
+        const serialized = `pending|${JSON.stringify(entry)}`;
+        pendingEntries = [
+          ...pendingEntries.filter((pending) => pending.field !== field),
+          { field, serialized, entry: structuredClone(entry) },
+        ];
+      },
+    );
+    pendingMocks.readPendingBrowseIndexEntries.mockImplementation(async () =>
+      structuredClone(pendingEntries),
+    );
+    pendingMocks.acknowledgePendingBrowseIndexEntries.mockImplementation(
+      async (
+        acknowledged: Array<{
+          field: string;
+          serialized: string;
+          entry: BrowseIndexEntry;
+        }>,
+      ) => {
+        pendingEntries = pendingEntries.filter(
+          (pending) =>
+            !acknowledged.some(
+              (candidate) =>
+                candidate.field === pending.field &&
+                candidate.serialized === pending.serialized,
+            ),
+        );
+      },
+    );
     storageMocks.getGzipJsonObject.mockImplementation(
       async (_bucket: string, key: string) => {
         const value = gzipObjects.get(key);
@@ -243,6 +288,50 @@ describe("browse diagram storage", () => {
     expect(gzipObjects.get(V3_MANIFEST_KEY)).toMatchObject({
       retainedSnapshotKeys: expect.arrayContaining([previousSnapshotKey]),
     });
+  });
+
+  it("keeps an update journaled when materialization exhausts its retries", async () => {
+    seedAtomicIndex([
+      {
+        username: "older",
+        repo: "repo",
+        lastSuccessfulAt: "2026-03-27T12:00:00.000Z",
+        stargazerCount: 5,
+      },
+    ]);
+    storageMocks.putGzipJsonObject.mockImplementation(
+      async (_bucket: string, key: string, payload: unknown) => {
+        if (key === V3_MANIFEST_KEY) {
+          throw new Error("R2 unavailable");
+        }
+        gzipObjects.set(key, structuredClone(payload));
+      },
+    );
+
+    await expect(
+      upsertBrowseIndexEntry({
+        username: "acme",
+        repo: "demo",
+        lastSuccessfulAt: "2026-03-29T12:00:00.000Z",
+        stargazerCount: 42,
+      }),
+    ).rejects.toThrow("R2 unavailable");
+    expect(pendingEntries).toHaveLength(1);
+    expect(
+      pendingMocks.acknowledgePendingBrowseIndexEntries,
+    ).not.toHaveBeenCalled();
+
+    storageMocks.putGzipJsonObject.mockImplementation(
+      async (_bucket: string, key: string, payload: unknown) => {
+        gzipObjects.set(key, structuredClone(payload));
+      },
+    );
+    await expect(migrateBrowseIndexToAtomicV3()).resolves.toBe(2);
+    expect(pendingEntries).toHaveLength(0);
+    const page = await getBrowsePage({});
+    expect(page.items[0]).toEqual(
+      expect.objectContaining({ username: "acme", repo: "demo" }),
+    );
   });
 
   it("keeps the committed index when cleanup of the previous snapshot fails", async () => {

--- a/src/server/storage/browse-diagrams.ts
+++ b/src/server/storage/browse-diagrams.ts
@@ -15,6 +15,11 @@ import {
   getJsonObject,
   putGzipJsonObject,
 } from "./r2";
+import {
+  acknowledgePendingBrowseIndexEntries,
+  enqueuePendingBrowseIndexEntry,
+  readPendingBrowseIndexEntries,
+} from "./browse-index-pending";
 
 const LEGACY_PUBLIC_BROWSE_INDEX_KEY = "public/v1/_meta/browse-index.json";
 const PUBLIC_BROWSE_INDEX_KEY = "public/v2/_meta/browse-index.json.gz";
@@ -163,6 +168,30 @@ function insertRecentEntry(
   entries.splice(low, 0, entry);
 }
 
+function applyBrowseIndexEntry(
+  entries: BrowseIndexEntry[],
+  rawEntry: BrowseIndexEntry,
+): boolean {
+  const entry = normalizeBrowseIndexEntry(rawEntry);
+  const existingIndex = entries.findIndex(
+    (candidate) =>
+      candidate.username === entry.username && candidate.repo === entry.repo,
+  );
+  const existingEntry = entries[existingIndex];
+  if (
+    existingEntry &&
+    pickPreferredEntry(existingEntry, entry) === existingEntry
+  ) {
+    return false;
+  }
+
+  if (existingIndex >= 0) {
+    entries.splice(existingIndex, 1);
+  }
+  insertRecentEntry(entries, entry);
+  return true;
+}
+
 function createBrowseSnapshotKey(generation: string): string {
   return `${PUBLIC_BROWSE_SNAPSHOT_PREFIX}${generation}.json.gz`;
 }
@@ -218,23 +247,13 @@ export async function migrateBrowseIndexToAtomicV3(): Promise<number> {
     key: PUBLIC_BROWSE_INDEX_LOCK_KEY,
     ttlMs: BROWSE_INDEX_LOCK_TTL_MS,
     waitMs: BROWSE_INDEX_LOCK_WAIT_MS,
-    callback: async () => {
-      const stored = await readStoredBrowseIndex();
-      if (!stored) {
-        throw new BrowseIndexNotFoundError();
-      }
-      if (stored.activeSnapshotKey) {
-        return stored.entries.length;
-      }
-
-      const entries = normalizeBrowseIndexEntries(stored.entries);
-      return (
-        await writeBrowseIndex({
-          entries,
-          retainedSnapshotKeys: [],
+    callback: async () =>
+      (
+        await materializePendingBrowseIndex({
+          generation: randomUUID(),
+          requireExistingIndex: true,
         })
-      ).length;
-    },
+      ).length,
   });
 }
 
@@ -321,11 +340,12 @@ async function writeBrowseIndex(
   const generation = dependencies.generation ?? randomUUID();
   const updatedAt = now.toISOString();
   const snapshotKey = createBrowseSnapshotKey(generation);
-  const retainedSnapshotKeys = [snapshotKey, ...params.retainedSnapshotKeys]
-    .filter((key, index, keys) => keys.indexOf(key) === index)
-    .slice(0, BROWSE_INDEX_RETAINED_SNAPSHOTS);
+  const retainedSnapshotKeys = Array.from(
+    new Set([snapshotKey, ...params.retainedSnapshotKeys]),
+  ).slice(0, BROWSE_INDEX_RETAINED_SNAPSHOTS);
+  const retainedSnapshotKeySet = new Set(retainedSnapshotKeys);
   const retiredSnapshotKeys = params.retainedSnapshotKeys.filter(
-    (key) => !retainedSnapshotKeys.includes(key),
+    (key) => !retainedSnapshotKeySet.has(key),
   );
 
   // The manifest is the atomic commit point. It is published only after the
@@ -347,26 +367,64 @@ async function writeBrowseIndex(
     entries: params.entries.slice(0, RECENT_BROWSE_INDEX_SIZE),
   } satisfies BrowseIndexManifestPayload);
 
-  for (const retiredSnapshotKey of retiredSnapshotKeys) {
-    try {
-      await deleteObjectFn(getPublicBucket(), retiredSnapshotKey);
-    } catch (error) {
-      console.warn(
-        JSON.stringify({
-          event: "browse.index.snapshot_cleanup_failed",
-          snapshot_key: retiredSnapshotKey,
-          error: error instanceof Error ? error.message : "Unknown error",
-        }),
-      );
-    }
-  }
+  await Promise.all(
+    retiredSnapshotKeys.map(async (retiredSnapshotKey) => {
+      try {
+        await deleteObjectFn(getPublicBucket(), retiredSnapshotKey);
+      } catch (error) {
+        console.warn(
+          JSON.stringify({
+            event: "browse.index.snapshot_cleanup_failed",
+            snapshot_key: retiredSnapshotKey,
+            error: error instanceof Error ? error.message : "Unknown error",
+          }),
+        );
+      }
+    }),
+  );
 
   return params.entries;
+}
+
+async function materializePendingBrowseIndex(params: {
+  generation: string;
+  requireExistingIndex?: boolean;
+}): Promise<BrowseIndexEntry[]> {
+  const [stored, pending] = await Promise.all([
+    readStoredBrowseIndex(),
+    readPendingBrowseIndexEntries(),
+  ]);
+  if (!stored && !pending.length && params.requireExistingIndex) {
+    throw new BrowseIndexNotFoundError();
+  }
+
+  const entries = stored?.activeSnapshotKey
+    ? stored.entries
+    : normalizeBrowseIndexEntries(stored?.entries ?? []);
+  let changed = false;
+  for (const pendingEntry of pending) {
+    changed = applyBrowseIndexEntry(entries, pendingEntry.entry) || changed;
+  }
+
+  const materializedEntries =
+    !stored?.activeSnapshotKey || changed
+      ? await writeBrowseIndex(
+          {
+            entries,
+            retainedSnapshotKeys: stored?.retainedSnapshotKeys ?? [],
+          },
+          { generation: params.generation },
+        )
+      : entries;
+  await acknowledgePendingBrowseIndexEntries(pending);
+  return materializedEntries;
 }
 
 export async function upsertBrowseIndexEntry(
   entry: BrowseIndexEntry,
 ): Promise<BrowseIndexEntry[]> {
+  const normalizedEntry = normalizeBrowseIndexEntry(entry);
+  await enqueuePendingBrowseIndexEntry(normalizedEntry);
   const generation = randomUUID();
   let lastError: unknown;
 
@@ -376,45 +434,7 @@ export async function upsertBrowseIndexEntry(
         key: PUBLIC_BROWSE_INDEX_LOCK_KEY,
         ttlMs: BROWSE_INDEX_LOCK_TTL_MS,
         waitMs: BROWSE_INDEX_LOCK_WAIT_MS,
-        callback: async () => {
-          const stored = await readStoredBrowseIndex();
-          const existingEntries = stored?.entries ?? [];
-          const normalizedEntry = normalizeBrowseIndexEntry(entry);
-          const existingIndex = existingEntries.findIndex(
-            (candidate) =>
-              candidate.username === normalizedEntry.username &&
-              candidate.repo === normalizedEntry.repo,
-          );
-          const existingEntry = existingEntries[existingIndex];
-
-          if (
-            existingEntry &&
-            pickPreferredEntry(existingEntry, normalizedEntry) === existingEntry
-          ) {
-            if (stored?.activeSnapshotKey) {
-              return existingEntries;
-            }
-            return writeBrowseIndex(
-              {
-                entries: existingEntries,
-                retainedSnapshotKeys: [],
-              },
-              { generation },
-            );
-          }
-
-          if (existingIndex >= 0) {
-            existingEntries.splice(existingIndex, 1);
-          }
-          insertRecentEntry(existingEntries, normalizedEntry);
-          return writeBrowseIndex(
-            {
-              entries: existingEntries,
-              retainedSnapshotKeys: stored?.retainedSnapshotKeys ?? [],
-            },
-            { generation },
-          );
-        },
+        callback: () => materializePendingBrowseIndex({ generation }),
       });
     } catch (error) {
       lastError = error;

--- a/src/server/storage/browse-diagrams.ts
+++ b/src/server/storage/browse-diagrams.ts
@@ -1,6 +1,5 @@
-import { getGzipJsonObject, getJsonObject, putGzipJsonObject } from "./r2";
-import { readRequiredEnv } from "./config";
-import { withDistributedLock } from "./distributed-lock";
+import { randomUUID } from "node:crypto";
+
 import { getBrowsePageFromEntries, toRepoKey } from "~/features/browse/catalog";
 import type {
   BrowseIndexEntry,
@@ -8,16 +7,31 @@ import type {
   BrowseQuery,
   RecentBrowseIndex,
 } from "~/features/browse/catalog";
+import { readRequiredEnv } from "./config";
+import { withDistributedLock } from "./distributed-lock";
+import {
+  deleteObject,
+  getGzipJsonObject,
+  getJsonObject,
+  putGzipJsonObject,
+} from "./r2";
 
 const LEGACY_PUBLIC_BROWSE_INDEX_KEY = "public/v1/_meta/browse-index.json";
 const PUBLIC_BROWSE_INDEX_KEY = "public/v2/_meta/browse-index.json.gz";
 const PUBLIC_RECENT_BROWSE_INDEX_KEY = "public/v2/_meta/browse-recent.json.gz";
+const PUBLIC_BROWSE_MANIFEST_KEY =
+  "public/v3/_meta/browse-index-manifest.json.gz";
+const PUBLIC_BROWSE_SNAPSHOT_PREFIX = "public/v3/_meta/browse-index-snapshot-";
 const PUBLIC_BROWSE_INDEX_LOCK_KEY = "lock:v1:public-browse-index";
+const BROWSE_INDEX_WRITE_ATTEMPTS = 3;
+const BROWSE_INDEX_LOCK_TTL_MS = 60_000;
+const BROWSE_INDEX_LOCK_WAIT_MS = 10_000;
+const BROWSE_INDEX_RETAINED_SNAPSHOTS = 8;
 export const RECENT_BROWSE_INDEX_SIZE = 2_000;
 
 export type { BrowseIndexEntry, BrowsePageResult, BrowseQuery };
 
-interface BrowseIndexPayload {
+interface LegacyBrowseIndexPayload {
   version: 1 | 2;
   updatedAt: string;
   entries: BrowseIndexEntry[];
@@ -28,12 +42,36 @@ interface RecentBrowseIndexPayload extends RecentBrowseIndex {
   updatedAt: string;
 }
 
+interface BrowseIndexSnapshotPayload {
+  version: 3;
+  generation: string;
+  updatedAt: string;
+  entries: BrowseIndexEntry[];
+}
+
+interface BrowseIndexManifestPayload extends RecentBrowseIndex {
+  version: 3;
+  generation: string;
+  updatedAt: string;
+  snapshotKey: string;
+  retainedSnapshotKeys?: string[];
+}
+
+interface StoredBrowseIndex {
+  entries: BrowseIndexEntry[];
+  activeSnapshotKey: string | null;
+  retainedSnapshotKeys: string[];
+}
+
 type PutGzipJsonObjectFn = typeof putGzipJsonObject;
+type DeleteObjectFn = typeof deleteObject;
 type ReadJsonObjectFn = <T>(bucket: string, key: string) => Promise<T | null>;
 
 export class BrowseIndexNotFoundError extends Error {
   constructor() {
-    super(`Browse index missing at ${PUBLIC_BROWSE_INDEX_KEY}.`);
+    super(
+      `Browse index missing at ${PUBLIC_BROWSE_MANIFEST_KEY} and legacy fallbacks.`,
+    );
     this.name = "BrowseIndexNotFoundError";
   }
 }
@@ -125,15 +163,42 @@ function insertRecentEntry(
   entries.splice(low, 0, entry);
 }
 
-async function readStoredBrowseIndex(): Promise<BrowseIndexEntry[] | null> {
+function createBrowseSnapshotKey(generation: string): string {
+  return `${PUBLIC_BROWSE_SNAPSHOT_PREFIX}${generation}.json.gz`;
+}
+
+function isBrowseSnapshotKey(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.startsWith(PUBLIC_BROWSE_SNAPSHOT_PREFIX) &&
+    value.endsWith(".json.gz")
+  );
+}
+
+async function readStoredBrowseIndex(): Promise<StoredBrowseIndex | null> {
   return readStoredBrowseIndexWith(getGzipJsonObject, getJsonObject);
 }
 
 export async function readBrowseIndex(): Promise<BrowseIndexEntry[] | null> {
-  return readStoredBrowseIndex();
+  return (await readStoredBrowseIndex())?.entries ?? null;
 }
 
 export async function readRecentBrowseIndex(): Promise<RecentBrowseIndex | null> {
+  const manifest = await getGzipJsonObject<BrowseIndexManifestPayload>(
+    getPublicBucket(),
+    PUBLIC_BROWSE_MANIFEST_KEY,
+  );
+  if (
+    manifest?.version === 3 &&
+    typeof manifest.generation === "string" &&
+    isBrowseSnapshotKey(manifest.snapshotKey)
+  ) {
+    return {
+      entries: manifest.entries ?? [],
+      total: manifest.total ?? 0,
+    };
+  }
+
   const stored = await getGzipJsonObject<RecentBrowseIndexPayload>(
     getPublicBucket(),
     PUBLIC_RECENT_BROWSE_INDEX_KEY,
@@ -148,42 +213,27 @@ export async function readRecentBrowseIndex(): Promise<RecentBrowseIndex | null>
   };
 }
 
-export async function migrateBrowseIndexToCompressedV2(): Promise<number> {
+export async function migrateBrowseIndexToAtomicV3(): Promise<number> {
   return withDistributedLock({
     key: PUBLIC_BROWSE_INDEX_LOCK_KEY,
+    ttlMs: BROWSE_INDEX_LOCK_TTL_MS,
+    waitMs: BROWSE_INDEX_LOCK_WAIT_MS,
     callback: async () => {
-      const [compressed, recent] = await Promise.all([
-        getGzipJsonObject<BrowseIndexPayload>(
-          getPublicBucket(),
-          PUBLIC_BROWSE_INDEX_KEY,
-        ),
-        getGzipJsonObject<RecentBrowseIndexPayload>(
-          getPublicBucket(),
-          PUBLIC_RECENT_BROWSE_INDEX_KEY,
-        ),
-      ]);
-      if (compressed?.version === 2 && recent?.version === 1) {
-        return compressed.entries?.length ?? 0;
-      }
-
-      const source =
-        compressed ??
-        (await getJsonObject<BrowseIndexPayload>(
-          getPublicBucket(),
-          LEGACY_PUBLIC_BROWSE_INDEX_KEY,
-        ));
-      if (!source) {
+      const stored = await readStoredBrowseIndex();
+      if (!stored) {
         throw new BrowseIndexNotFoundError();
       }
-
-      const normalizedEntries = normalizeBrowseIndexEntries(
-        source.entries ?? [],
-      );
-      if (compressed?.version === 2) {
-        await writeRecentBrowseIndex(normalizedEntries);
-        return normalizedEntries.length;
+      if (stored.activeSnapshotKey) {
+        return stored.entries.length;
       }
-      return (await writeBrowseIndex(normalizedEntries)).length;
+
+      const entries = normalizeBrowseIndexEntries(stored.entries);
+      return (
+        await writeBrowseIndex({
+          entries,
+          retainedSnapshotKeys: [],
+        })
+      ).length;
     },
   });
 }
@@ -191,14 +241,49 @@ export async function migrateBrowseIndexToCompressedV2(): Promise<number> {
 async function readStoredBrowseIndexWith(
   getGzipJsonObjectFn: ReadJsonObjectFn,
   getJsonObjectFn: ReadJsonObjectFn,
-): Promise<BrowseIndexEntry[] | null> {
-  const compressed = await getGzipJsonObjectFn<BrowseIndexPayload>(
+): Promise<StoredBrowseIndex | null> {
+  const manifest = await getGzipJsonObjectFn<BrowseIndexManifestPayload>(
+    getPublicBucket(),
+    PUBLIC_BROWSE_MANIFEST_KEY,
+  );
+  if (
+    manifest?.version === 3 &&
+    typeof manifest.generation === "string" &&
+    isBrowseSnapshotKey(manifest.snapshotKey)
+  ) {
+    const snapshot = await getGzipJsonObjectFn<BrowseIndexSnapshotPayload>(
+      getPublicBucket(),
+      manifest.snapshotKey,
+    );
+    if (
+      snapshot?.version === 3 &&
+      snapshot.generation === manifest.generation
+    ) {
+      return {
+        entries: snapshot.entries ?? [],
+        activeSnapshotKey: manifest.snapshotKey,
+        retainedSnapshotKeys: [
+          manifest.snapshotKey,
+          ...(manifest.retainedSnapshotKeys ?? []).filter(isBrowseSnapshotKey),
+        ].filter((key, index, keys) => keys.indexOf(key) === index),
+      };
+    }
+
+    console.error(
+      JSON.stringify({
+        event: "browse.index.snapshot_invalid",
+        generation: manifest.generation,
+      }),
+    );
+  }
+
+  const compressed = await getGzipJsonObjectFn<LegacyBrowseIndexPayload>(
     getPublicBucket(),
     PUBLIC_BROWSE_INDEX_KEY,
   );
   const stored =
     compressed ??
-    (await getJsonObjectFn<BrowseIndexPayload>(
+    (await getJsonObjectFn<LegacyBrowseIndexPayload>(
       getPublicBucket(),
       LEGACY_PUBLIC_BROWSE_INDEX_KEY,
     ));
@@ -207,79 +292,148 @@ async function readStoredBrowseIndexWith(
     return null;
   }
 
-  return stored.version === 2
-    ? (stored.entries ?? [])
-    : normalizeBrowseIndexEntries(stored.entries ?? []);
+  return {
+    entries:
+      stored.version === 2
+        ? (stored.entries ?? [])
+        : normalizeBrowseIndexEntries(stored.entries ?? []),
+    activeSnapshotKey: null,
+    retainedSnapshotKeys: [],
+  };
 }
 
 async function writeBrowseIndex(
-  entries: BrowseIndexEntry[],
-  putGzipJsonObjectFn: PutGzipJsonObjectFn = putGzipJsonObject,
-  now = new Date(),
+  params: {
+    entries: BrowseIndexEntry[];
+    retainedSnapshotKeys: string[];
+  },
+  dependencies: {
+    putGzipJsonObjectFn?: PutGzipJsonObjectFn;
+    deleteObjectFn?: DeleteObjectFn;
+    now?: Date;
+    generation?: string;
+  } = {},
 ): Promise<BrowseIndexEntry[]> {
+  const putGzipJsonObjectFn =
+    dependencies.putGzipJsonObjectFn ?? putGzipJsonObject;
+  const deleteObjectFn = dependencies.deleteObjectFn ?? deleteObject;
+  const now = dependencies.now ?? new Date();
+  const generation = dependencies.generation ?? randomUUID();
   const updatedAt = now.toISOString();
-  await Promise.all([
-    putGzipJsonObjectFn(getPublicBucket(), PUBLIC_BROWSE_INDEX_KEY, {
-      version: 2,
-      updatedAt,
-      entries,
-    } satisfies BrowseIndexPayload),
-    writeRecentBrowseIndex(entries, putGzipJsonObjectFn, now),
-  ]);
+  const snapshotKey = createBrowseSnapshotKey(generation);
+  const retainedSnapshotKeys = [snapshotKey, ...params.retainedSnapshotKeys]
+    .filter((key, index, keys) => keys.indexOf(key) === index)
+    .slice(0, BROWSE_INDEX_RETAINED_SNAPSHOTS);
+  const retiredSnapshotKeys = params.retainedSnapshotKeys.filter(
+    (key) => !retainedSnapshotKeys.includes(key),
+  );
 
-  return entries;
+  // The manifest is the atomic commit point. It is published only after the
+  // full snapshot exists and embeds the recent projection, so readers cannot
+  // observe mismatched full and recent indexes.
+  await putGzipJsonObjectFn(getPublicBucket(), snapshotKey, {
+    version: 3,
+    generation,
+    updatedAt,
+    entries: params.entries,
+  } satisfies BrowseIndexSnapshotPayload);
+  await putGzipJsonObjectFn(getPublicBucket(), PUBLIC_BROWSE_MANIFEST_KEY, {
+    version: 3,
+    generation,
+    updatedAt,
+    snapshotKey,
+    retainedSnapshotKeys,
+    total: params.entries.length,
+    entries: params.entries.slice(0, RECENT_BROWSE_INDEX_SIZE),
+  } satisfies BrowseIndexManifestPayload);
+
+  for (const retiredSnapshotKey of retiredSnapshotKeys) {
+    try {
+      await deleteObjectFn(getPublicBucket(), retiredSnapshotKey);
+    } catch (error) {
+      console.warn(
+        JSON.stringify({
+          event: "browse.index.snapshot_cleanup_failed",
+          snapshot_key: retiredSnapshotKey,
+          error: error instanceof Error ? error.message : "Unknown error",
+        }),
+      );
+    }
+  }
+
+  return params.entries;
 }
 
-async function writeRecentBrowseIndex(
-  entries: BrowseIndexEntry[],
-  putGzipJsonObjectFn: PutGzipJsonObjectFn = putGzipJsonObject,
-  now = new Date(),
-): Promise<void> {
-  await putGzipJsonObjectFn(getPublicBucket(), PUBLIC_RECENT_BROWSE_INDEX_KEY, {
-    version: 1,
-    updatedAt: now.toISOString(),
-    total: entries.length,
-    entries: entries.slice(0, RECENT_BROWSE_INDEX_SIZE),
-  } satisfies RecentBrowseIndexPayload);
-}
 export async function upsertBrowseIndexEntry(
   entry: BrowseIndexEntry,
 ): Promise<BrowseIndexEntry[]> {
-  return withDistributedLock({
-    key: PUBLIC_BROWSE_INDEX_LOCK_KEY,
-    callback: async () => {
-      const existingEntries = (await readStoredBrowseIndex()) ?? [];
-      const normalizedEntry = normalizeBrowseIndexEntry(entry);
-      const existingIndex = existingEntries.findIndex(
-        (candidate) =>
-          candidate.username === normalizedEntry.username &&
-          candidate.repo === normalizedEntry.repo,
-      );
-      const existingEntry = existingEntries[existingIndex];
+  const generation = randomUUID();
+  let lastError: unknown;
 
-      if (
-        existingEntry &&
-        pickPreferredEntry(existingEntry, normalizedEntry) === existingEntry
-      ) {
-        return existingEntries;
-      }
+  for (let attempt = 1; attempt <= BROWSE_INDEX_WRITE_ATTEMPTS; attempt++) {
+    try {
+      return await withDistributedLock({
+        key: PUBLIC_BROWSE_INDEX_LOCK_KEY,
+        ttlMs: BROWSE_INDEX_LOCK_TTL_MS,
+        waitMs: BROWSE_INDEX_LOCK_WAIT_MS,
+        callback: async () => {
+          const stored = await readStoredBrowseIndex();
+          const existingEntries = stored?.entries ?? [];
+          const normalizedEntry = normalizeBrowseIndexEntry(entry);
+          const existingIndex = existingEntries.findIndex(
+            (candidate) =>
+              candidate.username === normalizedEntry.username &&
+              candidate.repo === normalizedEntry.repo,
+          );
+          const existingEntry = existingEntries[existingIndex];
 
-      if (existingIndex >= 0) {
-        existingEntries.splice(existingIndex, 1);
+          if (
+            existingEntry &&
+            pickPreferredEntry(existingEntry, normalizedEntry) === existingEntry
+          ) {
+            if (stored?.activeSnapshotKey) {
+              return existingEntries;
+            }
+            return writeBrowseIndex(
+              {
+                entries: existingEntries,
+                retainedSnapshotKeys: [],
+              },
+              { generation },
+            );
+          }
+
+          if (existingIndex >= 0) {
+            existingEntries.splice(existingIndex, 1);
+          }
+          insertRecentEntry(existingEntries, normalizedEntry);
+          return writeBrowseIndex(
+            {
+              entries: existingEntries,
+              retainedSnapshotKeys: stored?.retainedSnapshotKeys ?? [],
+            },
+            { generation },
+          );
+        },
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt < BROWSE_INDEX_WRITE_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 100));
       }
-      insertRecentEntry(existingEntries, normalizedEntry);
-      return writeBrowseIndex(existingEntries);
-    },
-  });
+    }
+  }
+
+  throw lastError;
 }
 
 export async function getBrowsePage(
   query: BrowseQuery,
 ): Promise<BrowsePageResult> {
-  const storedEntries = await readStoredBrowseIndex();
-  if (!storedEntries) {
+  const stored = await readStoredBrowseIndex();
+  if (!stored) {
     throw new BrowseIndexNotFoundError();
   }
 
-  return getBrowsePageFromEntries(storedEntries, query);
+  return getBrowsePageFromEntries(stored.entries, query);
 }

--- a/src/server/storage/browse-index-pending.test.ts
+++ b/src/server/storage/browse-index-pending.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const upstashMocks = vi.hoisted(() => ({
+  command: vi.fn(),
+  eval: vi.fn(),
+}));
+
+vi.mock("./upstash", () => ({
+  upstashCommand: upstashMocks.command,
+  upstashEval: upstashMocks.eval,
+}));
+
+import {
+  acknowledgePendingBrowseIndexEntries,
+  enqueuePendingBrowseIndexEntry,
+  readPendingBrowseIndexEntries,
+} from "./browse-index-pending";
+
+describe("pending browse index journal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    upstashMocks.command.mockResolvedValue([]);
+    upstashMocks.eval.mockResolvedValue(1);
+  });
+
+  it("atomically keeps the newest entry for each repository", async () => {
+    await enqueuePendingBrowseIndexEntry({
+      username: "acme",
+      repo: "demo",
+      lastSuccessfulAt: "2026-07-24T12:00:00.000Z",
+      stargazerCount: 42,
+    });
+
+    expect(upstashMocks.eval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keys: ["pending:v1:public-browse-index"],
+        args: [
+          "acme/demo",
+          expect.stringMatching(/:1$/),
+          expect.stringContaining(
+            '"lastSuccessfulAt":"2026-07-24T12:00:00.000Z"',
+          ),
+        ],
+      }),
+    );
+  });
+
+  it("reads valid journal entries and skips malformed values", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const entry = {
+      username: "acme",
+      repo: "demo",
+      lastSuccessfulAt: "2026-07-24T12:00:00.000Z",
+      stargazerCount: 42,
+    };
+    const serialized = `1784919600000:1|${JSON.stringify(entry)}`;
+    upstashMocks.command.mockResolvedValue([
+      "acme/demo",
+      serialized,
+      "broken/repo",
+      "1784919600000:1|{",
+    ]);
+
+    await expect(readPendingBrowseIndexEntries()).resolves.toEqual([
+      {
+        field: "acme/demo",
+        serialized,
+        entry,
+      },
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("browse.index.pending_entry_invalid"),
+    );
+  });
+
+  it("acknowledges only the exact journal values that were materialized", async () => {
+    const pending = [
+      {
+        field: "acme/demo",
+        serialized: '1784919600000:1|{"repo":"demo"}',
+        entry: {
+          username: "acme",
+          repo: "demo",
+          lastSuccessfulAt: "2026-07-24T12:00:00.000Z",
+          stargazerCount: 42,
+        },
+      },
+    ];
+
+    await acknowledgePendingBrowseIndexEntries(pending);
+
+    expect(upstashMocks.eval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keys: ["pending:v1:public-browse-index"],
+        args: ["acme/demo", pending[0]?.serialized],
+      }),
+    );
+  });
+});

--- a/src/server/storage/browse-index-pending.ts
+++ b/src/server/storage/browse-index-pending.ts
@@ -1,0 +1,130 @@
+import { toRepoKey, type BrowseIndexEntry } from "~/features/browse/catalog";
+import { upstashCommand, upstashEval } from "./upstash";
+
+const PENDING_BROWSE_INDEX_KEY = "pending:v1:public-browse-index";
+
+const UPSERT_PENDING_BROWSE_ENTRY_SCRIPT = `
+local existing = redis.call("HGET", KEYS[1], ARGV[1])
+if existing then
+  local separator = string.find(existing, "|", 1, true)
+  if separator then
+    local existing_sort_key = string.sub(existing, 1, separator - 1)
+    if existing_sort_key >= ARGV[2] then
+      return 0
+    end
+  end
+end
+redis.call("HSET", KEYS[1], ARGV[1], ARGV[3])
+return 1
+`;
+
+const ACKNOWLEDGE_PENDING_BROWSE_ENTRIES_SCRIPT = `
+local removed = 0
+for index = 1, #ARGV, 2 do
+  local field = ARGV[index]
+  local expected = ARGV[index + 1]
+  if redis.call("HGET", KEYS[1], field) == expected then
+    removed = removed + redis.call("HDEL", KEYS[1], field)
+  end
+end
+return removed
+`;
+
+export interface PendingBrowseIndexEntry {
+  field: string;
+  serialized: string;
+  entry: BrowseIndexEntry;
+}
+
+function createPendingSortKey(entry: BrowseIndexEntry): string {
+  const timestamp = Date.parse(entry.lastSuccessfulAt);
+  const timestampKey = String(
+    Number.isFinite(timestamp) ? timestamp : 0,
+  ).padStart(13, "0");
+  const metadataKey = entry.stargazerCount === null ? "0" : "1";
+  return `${timestampKey}:${metadataKey}`;
+}
+
+function serializePendingEntry(entry: BrowseIndexEntry): string {
+  return `${createPendingSortKey(entry)}|${JSON.stringify(entry)}`;
+}
+
+function isBrowseIndexEntry(value: unknown): value is BrowseIndexEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<BrowseIndexEntry>;
+  return (
+    typeof candidate.username === "string" &&
+    typeof candidate.repo === "string" &&
+    typeof candidate.lastSuccessfulAt === "string" &&
+    (candidate.stargazerCount === null ||
+      typeof candidate.stargazerCount === "number")
+  );
+}
+
+export async function enqueuePendingBrowseIndexEntry(
+  entry: BrowseIndexEntry,
+): Promise<void> {
+  const field = toRepoKey(entry);
+  const serialized = serializePendingEntry(entry);
+  await upstashEval<number>({
+    script: UPSERT_PENDING_BROWSE_ENTRY_SCRIPT,
+    keys: [PENDING_BROWSE_INDEX_KEY],
+    args: [field, createPendingSortKey(entry), serialized],
+  });
+}
+
+export async function readPendingBrowseIndexEntries(): Promise<
+  PendingBrowseIndexEntry[]
+> {
+  const values = await upstashCommand<string[]>([
+    "HGETALL",
+    PENDING_BROWSE_INDEX_KEY,
+  ]);
+  const pending: PendingBrowseIndexEntry[] = [];
+
+  for (let index = 0; index < values.length; index += 2) {
+    const field = values[index];
+    const serialized = values[index + 1];
+    const separator = serialized?.indexOf("|") ?? -1;
+    if (!field || !serialized || separator < 0) {
+      continue;
+    }
+
+    try {
+      const entry = JSON.parse(serialized.slice(separator + 1)) as unknown;
+      if (!isBrowseIndexEntry(entry)) {
+        throw new Error("Invalid browse index entry.");
+      }
+      pending.push({
+        field,
+        serialized,
+        entry,
+      });
+    } catch {
+      console.error(
+        JSON.stringify({
+          event: "browse.index.pending_entry_invalid",
+          field,
+        }),
+      );
+    }
+  }
+
+  return pending;
+}
+
+export async function acknowledgePendingBrowseIndexEntries(
+  pending: PendingBrowseIndexEntry[],
+): Promise<void> {
+  if (!pending.length) {
+    return;
+  }
+
+  await upstashEval<number>({
+    script: ACKNOWLEDGE_PENDING_BROWSE_ENTRIES_SCRIPT,
+    keys: [PENDING_BROWSE_INDEX_KEY],
+    args: pending.flatMap(({ field, serialized }) => [field, serialized]),
+  });
+}

--- a/src/server/storage/r2.ts
+++ b/src/server/storage/r2.ts
@@ -141,3 +141,14 @@ export async function putGzipJsonObject(
     requestOptions(),
   );
 }
+
+export async function deleteObject(bucket: string, key: string): Promise<void> {
+  const { client: storageClient, s3 } = await getClient();
+  await storageClient.send(
+    new s3.DeleteObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    }),
+    requestOptions(),
+  );
+}


### PR DESCRIPTION
## Summary

- require caller-supplied GitHub credentials before server credentials can read private repository contents, and suppress private OG metadata
- replace lossy browse-index rewrites with an atomic v3 snapshot/manifest protocol backed by a durable Upstash pending journal
- report incomplete generation usage as an attempt-aware estimate instead of an actual cost
- extract generation request admission from the streaming route, including rate-limit refunds for pre-billable failures

This branch is rebased onto Claude Code’s concurrent hardening commit `c43f7f4`; the changes were developed in a separate worktree to avoid overlapping edits.

## Validation

- `bun run check`
- `NODE_OPTIONS=--no-experimental-webstorage bun run test` (62 files, 355 tests)
- `bun run format:check`
- `bunx knip --reporter compact`
- `bun audit`
- `bun run build`
- `bun run perf:budget`
- React Doctor: 97/100, no issues found
- `git diff --check`