### PR TITLE
Fix issue #140: Added an export to PDF button

### DIFF
--- a/src/app/[username]/[repo]/repo-page-client.test.tsx
+++ b/src/app/[username]/[repo]/repo-page-client.test.tsx
@@ -72,6 +72,7 @@ describe("RepoPageClient", () => {
       handleCloseApiKeyDialog: vi.fn(),
       handleOpenApiKeyDialog: vi.fn(),
       handleExportImage: vi.fn(),
+      handleExportPdf: vi.fn(),
       handleRegenerate: vi.fn(),
       handleDiagramRenderError: vi.fn(),
       state: {
@@ -107,6 +108,7 @@ describe("RepoPageClient", () => {
       handleCloseApiKeyDialog: vi.fn(),
       handleOpenApiKeyDialog: vi.fn(),
       handleExportImage: vi.fn(),
+      handleExportPdf: vi.fn(),
       handleRegenerate: vi.fn(),
       handleDiagramRenderError: vi.fn(),
       state: {
@@ -137,6 +139,7 @@ describe("RepoPageClient", () => {
       handleCloseApiKeyDialog: vi.fn(),
       handleOpenApiKeyDialog: vi.fn(),
       handleExportImage: vi.fn(),
+      handleExportPdf: vi.fn(),
       handleRegenerate: vi.fn(),
       handleDiagramRenderError: vi.fn(),
       state: {
@@ -166,6 +169,7 @@ describe("RepoPageClient", () => {
       handleCloseApiKeyDialog: vi.fn(),
       handleOpenApiKeyDialog: vi.fn(),
       handleExportImage: vi.fn(),
+      handleExportPdf: vi.fn(),
       handleRegenerate: vi.fn(),
       handleDiagramRenderError: vi.fn(),
       state: {
@@ -201,6 +205,7 @@ describe("RepoPageClient", () => {
       handleCloseApiKeyDialog: vi.fn(),
       handleOpenApiKeyDialog: vi.fn(),
       handleExportImage: vi.fn(),
+      handleExportPdf: vi.fn(),
       handleRegenerate: vi.fn(),
       handleDiagramRenderError: vi.fn(),
       state: {

--- a/src/app/[username]/[repo]/repo-page-client.tsx
+++ b/src/app/[username]/[repo]/repo-page-client.tsx
@@ -55,6 +55,7 @@ export default function RepoPageClient({
     handleCloseApiKeyDialog,
     handleOpenApiKeyDialog,
     handleExportImage,
+    handleExportPdf,
     handleRegenerate,
     handleDiagramRenderError,
     state,
@@ -112,6 +113,7 @@ export default function RepoPageClient({
             lastGenerated={lastGenerated}
             costSummary={state.costSummary}
             onExportImage={handleExportImage}
+            onExportPdf={handleExportPdf}
             onRegenerate={handleRegenerate}
             zoomingEnabled={zoomingEnabled}
             onZoomToggle={() => setZoomingEnabled((prev) => !prev)}

--- a/src/components/export-dropdown.tsx
+++ b/src/components/export-dropdown.tsx
@@ -1,5 +1,5 @@
 import { CopyButton } from "./copy-button";
-import { Image as ImageIcon } from "lucide-react";
+import { FileText, Image as ImageIcon } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import {
   Tooltip,
@@ -13,6 +13,7 @@ interface ExportDropdownProps {
   lastGenerated?: Date;
   costSummary?: GenerationCostSummary;
   onExportImage: () => void;
+  onExportPdf: () => void;
 }
 
 export function ExportDropdown({
@@ -20,6 +21,7 @@ export function ExportDropdown({
   lastGenerated,
   costSummary,
   onExportImage,
+  onExportPdf,
 }: ExportDropdownProps) {
   return (
     <div className="space-y-3 sm:space-y-4">
@@ -39,6 +41,23 @@ export function ExportDropdown({
           </TooltipTrigger>
           <TooltipContent>
             <p>Download diagram as high-quality PNG</p>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={(event) => {
+                event.preventDefault();
+                onExportPdf();
+              }}
+              className="neo-button h-11 w-full px-3 text-sm sm:h-10 sm:w-auto sm:p-6 sm:px-6 sm:text-lg"
+            >
+              <FileText className="h-6 w-6" />
+              <span className="text-sm">Download PDF</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Download diagram as PDF that fills the page</p>
           </TooltipContent>
         </Tooltip>
         <CopyButton onClick={onCopy} />

--- a/src/components/main-card.tsx
+++ b/src/components/main-card.tsx
@@ -21,6 +21,7 @@ interface MainCardProps {
   lastGenerated?: Date;
   costSummary?: GenerationCostSummary;
   onExportImage?: () => void;
+  onExportPdf?: () => void;
   onRegenerate?: () => void;
   zoomingEnabled?: boolean;
   onZoomToggle?: () => void;
@@ -36,6 +37,7 @@ export default function MainCard({
   lastGenerated,
   costSummary,
   onExportImage,
+  onExportPdf,
   onRegenerate,
   zoomingEnabled,
   onZoomToggle,
@@ -146,7 +148,7 @@ export default function MainCard({
                       </span>
                     </button>
                   )}
-                  {hasDiagram && onCopy && onExportImage && (
+                  {hasDiagram && onCopy && onExportImage && onExportPdf && (
                     <button
                       type="button"
                       onClick={(e) => {
@@ -195,6 +197,7 @@ export default function MainCard({
                       lastGenerated={lastGenerated}
                       costSummary={costSummary}
                       onExportImage={onExportImage!}
+                      onExportPdf={onExportPdf!}
                     />
                   </div>
                 ) : null}

--- a/src/features/diagram/export.ts
+++ b/src/features/diagram/export.ts
@@ -1,6 +1,9 @@
 const PNG_EXPORT_SCALE = 4;
 const MAX_PNG_EXPORT_DIMENSION = 16_384;
 const MAX_PNG_EXPORT_PIXELS = 32_000_000;
+/** Longest PDF page side in points (~11"), so the diagram fills a printable page. */
+const PDF_MAX_PAGE_SIDE_PT = 792;
+const PDF_JPEG_QUALITY = 0.92;
 
 function loadSvgImage(sourceUrl: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
@@ -23,6 +26,22 @@ function encodeCanvasAsPng(canvas: HTMLCanvasElement): Promise<Blob> {
   });
 }
 
+function encodeCanvasAsJpeg(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Unable to encode diagram JPEG for PDF."));
+        }
+      },
+      "image/jpeg",
+      PDF_JPEG_QUALITY,
+    );
+  });
+}
+
 function downloadBlob(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
@@ -34,9 +53,11 @@ function downloadBlob(blob: Blob, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-export async function exportMermaidSvgAsPng(
-  svgElement: SVGSVGElement,
-): Promise<void> {
+function getExportDimensions(svgElement: SVGSVGElement): {
+  width: number;
+  height: number;
+  scale: number;
+} {
   const bbox = svgElement.getBBox();
   const viewBox = svgElement.viewBox.baseVal;
   const width = viewBox.width > 0 ? viewBox.width : bbox.width;
@@ -53,7 +74,15 @@ export async function exportMermaidSvgAsPng(
   if (!Number.isFinite(scale) || scale <= 0) {
     throw new Error("Diagram is too large to export.");
   }
+  return { width, height, scale };
+}
 
+async function renderSvgToCanvas(svgElement: SVGSVGElement): Promise<{
+  canvas: HTMLCanvasElement;
+  width: number;
+  height: number;
+}> {
+  const { width, height, scale } = getExportDimensions(svgElement);
   const svgData = new XMLSerializer().serializeToString(svgElement);
   const svgBlob = new Blob([svgData], {
     type: "image/svg+xml;charset=utf-8",
@@ -76,11 +105,108 @@ export async function exportMermaidSvgAsPng(
     context.scale(scale, scale);
     context.drawImage(image, 0, 0, width, height);
 
-    // Encoding is asynchronous, avoiding the large synchronous base64 string
-    // created by toDataURL for high-resolution diagrams.
-    const pngBlob = await encodeCanvasAsPng(canvas);
-    downloadBlob(pngBlob, "diagram.png");
+    return { canvas, width: canvas.width, height: canvas.height };
   } finally {
     URL.revokeObjectURL(svgUrl);
   }
+}
+
+/**
+ * Build a one-page PDF whose MediaBox matches the diagram aspect ratio, so the
+ * image fills the page with no cropping regardless of width/height.
+ */
+function buildPdfFromJpeg(
+  jpegBytes: Uint8Array,
+  imageWidth: number,
+  imageHeight: number,
+): Blob {
+  const scale = Math.min(
+    PDF_MAX_PAGE_SIDE_PT / imageWidth,
+    PDF_MAX_PAGE_SIDE_PT / imageHeight,
+  );
+  const pageWidth = imageWidth * scale;
+  const pageHeight = imageHeight * scale;
+
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const objectOffsets: number[] = [0];
+  let offset = 0;
+
+  const push = (chunk: string | Uint8Array) => {
+    const bytes = typeof chunk === "string" ? encoder.encode(chunk) : chunk;
+    parts.push(bytes);
+    offset += bytes.length;
+  };
+
+  const pushObject = (content: string | Uint8Array[]) => {
+    objectOffsets.push(offset);
+    if (typeof content === "string") {
+      push(content);
+    } else {
+      for (const chunk of content) {
+        push(chunk);
+      }
+    }
+  };
+
+  push("%PDF-1.4\n");
+
+  pushObject("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+  pushObject("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+  pushObject(
+    `3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${pageWidth.toFixed(2)} ${pageHeight.toFixed(2)}] /Contents 4 0 R /Resources << /XObject << /Im0 5 0 R >> >> >>\nendobj\n`,
+  );
+
+  const contentStream = `q\n${pageWidth.toFixed(2)} 0 0 ${pageHeight.toFixed(2)} 0 0 cm\n/Im0 Do\nQ\n`;
+  pushObject(
+    `4 0 obj\n<< /Length ${encoder.encode(contentStream).length} >>\nstream\n${contentStream}endstream\nendobj\n`,
+  );
+
+  pushObject([
+    encoder.encode(
+      `5 0 obj\n<< /Type /XObject /Subtype /Image /Width ${imageWidth} /Height ${imageHeight} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${jpegBytes.length} >>\nstream\n`,
+    ),
+    jpegBytes,
+    encoder.encode("\nendstream\nendobj\n"),
+  ]);
+
+  const xrefOffset = offset;
+  const objectCount = objectOffsets.length;
+  push(`xref\n0 ${objectCount}\n`);
+  push("0000000000 65535 f \n");
+  for (let i = 1; i < objectCount; i++) {
+    push(`${String(objectOffsets[i]).padStart(10, "0")} 00000 n \n`);
+  }
+  push(
+    `trailer\n<< /Size ${objectCount} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`,
+  );
+
+  // Copy into a fresh ArrayBuffer-backed view so Blob accepts the parts under
+  // TypeScript's ArrayBuffer-only BlobPart typing.
+  const buffers = parts.map((part) => {
+    const copy = new Uint8Array(part.byteLength);
+    copy.set(part);
+    return copy;
+  });
+  return new Blob(buffers, { type: "application/pdf" });
+}
+
+export async function exportMermaidSvgAsPng(
+  svgElement: SVGSVGElement,
+): Promise<void> {
+  const { canvas } = await renderSvgToCanvas(svgElement);
+  // Encoding is asynchronous, avoiding the large synchronous base64 string
+  // created by toDataURL for high-resolution diagrams.
+  const pngBlob = await encodeCanvasAsPng(canvas);
+  downloadBlob(pngBlob, "diagram.png");
+}
+
+export async function exportMermaidSvgAsPdf(
+  svgElement: SVGSVGElement,
+): Promise<void> {
+  const { canvas, width, height } = await renderSvgToCanvas(svgElement);
+  const jpegBlob = await encodeCanvasAsJpeg(canvas);
+  const jpegBytes = new Uint8Array(await jpegBlob.arrayBuffer());
+  const pdfBlob = buildPdfFromJpeg(jpegBytes, width, height);
+  downloadBlob(pdfBlob, "diagram.pdf");
 }

--- a/src/hooks/diagram/useDiagramExport.ts
+++ b/src/hooks/diagram/useDiagramExport.ts
@@ -1,6 +1,9 @@
 import { useCallback } from "react";
 
-import { exportMermaidSvgAsPng } from "~/features/diagram/export";
+import {
+  exportMermaidSvgAsPdf,
+  exportMermaidSvgAsPng,
+} from "~/features/diagram/export";
 
 export function useDiagramExport(diagram: string) {
   const handleCopy = useCallback(async () => {
@@ -16,8 +19,18 @@ export function useDiagramExport(diagram: string) {
     });
   }, []);
 
+  const handleExportPdf = useCallback(() => {
+    const svgElement = document.querySelector(".mermaid svg");
+    if (!(svgElement instanceof SVGSVGElement)) return;
+
+    void exportMermaidSvgAsPdf(svgElement).catch((error: unknown) => {
+      console.error("Diagram PDF export failed:", error);
+    });
+  }, []);
+
   return {
     handleCopy,
     handleExportImage,
+    handleExportPdf,
   };
 }

--- a/src/hooks/useDiagram.test.ts
+++ b/src/hooks/useDiagram.test.ts
@@ -126,6 +126,7 @@ describe("useDiagram", () => {
     useDiagramExport.mockReturnValue({
       handleCopy: vi.fn(),
       handleExportImage: vi.fn(),
+      handleExportPdf: vi.fn(),
     });
     setStreamState.mockReset();
     runGeneration.mockImplementation(async () => {

--- a/src/hooks/useDiagram.ts
+++ b/src/hooks/useDiagram.ts
@@ -351,7 +351,8 @@ export function useDiagram(
 
   const diagram = state.diagram ?? "";
   const error = state.error ?? "";
-  const { handleCopy, handleExportImage } = useDiagramExport(diagram);
+  const { handleCopy, handleExportImage, handleExportPdf } =
+    useDiagramExport(diagram);
 
   const handleApiKeySaved = async () => {
     await runGenerationOperation(
@@ -391,6 +392,7 @@ export function useDiagram(
     handleCloseApiKeyDialog,
     handleOpenApiKeyDialog,
     handleExportImage,
+    handleExportPdf,
     handleRegenerate,
     handleDiagramRenderError,
     state,


### PR DESCRIPTION
This pull request addresses Issue #140 by adding an Export to PDF button to the generated diagram page.

On mobile devices, complex diagrams can be difficult to read due to the limited screen size. The new export functionality allows users to download the diagram as a PDF, making it easier to zoom, view, and share on any device.

Changes:
- Added an Export to PDF button to the diagram interface.
- Implemented PDF generation for the currently displayed diagram.
- Ensured the exported PDF preserves the diagram content for improved readability.

Motivation:
- This enhancement improves the mobile user experience by providing a convenient way to view diagrams at a larger scale and access them offline.
- Closes #140.